### PR TITLE
Setup Prettier for auto formatting

### DIFF
--- a/.github/workflows/www.yml
+++ b/.github/workflows/www.yml
@@ -1,48 +1,48 @@
 name: Deploy VitePress
 on:
-  push:
-    branches: ["main"]
+    push:
+        branches: ['main']
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+    contents: read
+    pages: write
+    id-token: write
 
 # Allow one concurrent deployment
 concurrency:
-  group: "pages"
-  cancel-in-progress: true
+    group: 'pages'
+    cancel-in-progress: true
 
 jobs:
-  # Build job
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Pages
-        uses: actions/configure-pages@v2
-      - name: Build with VitePress
-        uses: actions/setup-node@v3
-      - run: npm i
-      - run: npm run docs:build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: .vitepress/dist
+    # Build job
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+            - name: Setup Pages
+              uses: actions/configure-pages@v2
+            - name: Build with VitePress
+              uses: actions/setup-node@v3
+            - run: npm i
+            - run: npm run docs:build
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v1
+              with:
+                  path: .vitepress/dist
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
+    # Deployment job
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        needs: build
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v1

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 4,
+    "semi": false,
+    "singleQuote": true
+}

--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -2,105 +2,169 @@ import { defineConfig } from 'vitepress'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  srcDir: 'www',
-  ignoreDeadLinks: true,
-  title: "Garph",
-  description: "GraphQL. Reimagined",
-  lastUpdated: true,
-  markdown: {
-    theme: {
-      light: 'github-light',
-      dark: 'github-dark',
-    },
-  },
-  themeConfig: {
-    // https://vitepress.dev/reference/default-theme-config
-    logo: {
-      light: '/logo/r6N.svg',
-      dark: '/logo/r5m.svg',
-    },
-    // logo: {
-    //   light: '/logo/r6p.svg',
-    //   dark: '/logo/r5y.svg'
-    // },
-    siteTitle: false,
-    nav: [
-      { text: 'Home', link: '/' },
-      { text: 'Docs', link: '/docs/index.md' },
-      { text: 'API', link: '/api/index.md' }
-    ],
-    socialLinks: [
-      { icon: 'github', link: 'https://github.com/stepci/garph' },
-      { icon: 'twitter', link: 'https://twitter.com/ci_step' },
-      { icon: 'discord', link: 'https://discord.gg/KqJJzJ3BTu' }
-    ],
-    editLink: {
-      pattern: 'https://github.com/stepci/garph/edit/main/www/:path',
-      text: 'Edit this page on GitHub'
-    },
-    outline: [2, 3],
-    sidebar: {
-      '/docs': [
-        {
-          text: 'Guide',
-          items: [
-            { text: 'Quickstart', link: '/docs/index.md' },
-            { text: 'Schemas', link: '/docs/guide/schemas.md' },
-            { text: 'Resolvers', link: '/docs/guide/resolvers.md' },
-            { text: 'Loaders', link: '/docs/guide/loaders.md' },
-            { text: 'Inferring Types', link: '/docs/guide/inferring-types.md' },
-            { text: 'Migrate <span class="badge-new">New</span>', link: '/docs/guide/migrate.md' }
-          ]
+    srcDir: 'www',
+    ignoreDeadLinks: true,
+    title: 'Garph',
+    description: 'GraphQL. Reimagined',
+    lastUpdated: true,
+    markdown: {
+        theme: {
+            light: 'github-light',
+            dark: 'github-dark',
         },
-        {
-          text: 'Advanced',
-          items: [
-            { text: 'Auth', link: '/docs/advanced/auth.md' },
-            { text: 'Context', link: '/docs/advanced/context.md' },
-            { text: 'File Uploads', link: '/docs/advanced/file-uploads.md' },
-            { text: 'Defer and Stream', link: '/docs/advanced/defer-stream.md' },
-            { text: 'Subscriptions', link: '/docs/advanced/subscriptions.md' },
-            { text: 'Pagination', link: '/docs/advanced/pagination.md' },
-            { text: 'Relay', link: '/docs/advanced/relay.md' },
-            { text: 'Validation', link: '/docs/advanced/validation.md' },
-            { text: 'Federation', link: '/docs/advanced/federation.md' },
-            { text: 'Errors', link: '/docs/advanced/errors.md' },
-            { text: 'Testing', link: '/docs/advanced/testing.md' },
-            { text: 'Extending Garph', link: '/docs/advanced/extending-garph.md' },
-          ]
+    },
+    themeConfig: {
+        // https://vitepress.dev/reference/default-theme-config
+        logo: {
+            light: '/logo/r6N.svg',
+            dark: '/logo/r5m.svg',
         },
-        {
-          text: 'Integration',
-          items: [
-            {
-              text: 'Examples', collapsed: true, items: [
-                { text: `Next.js <small style="display: block">Yoga + GQty</small>`, link:'/docs/integration/examples/nextjs.md' },
-                { text: 'Nuxt <small style="display: block">Yoga + Vue Apollo</small>', link:'/docs/integration/examples/nuxt.md' },
-                { text: 'Remix <small style="display: block">Yoga + GQty</small>', link:'/docs/integration/examples/remix.md' },
-              ]
-            },
-            {
-              text: 'Server', collapsed: true, items: [
-                { text: 'Yoga', link:'/docs/integration/server/graphql-yoga.md' },
-                { text: 'Apollo Server', link:'/docs/integration/server/apollo-server.md' },
-                { text: 'Mercurius', link:'/docs/integration/server/mercurius.md' },
-              ]
-            },
-            {
-              text: 'Client', collapsed: true, items: [
-                { text: 'GQty — Universal', link:'/docs/integration/client/gqty.md' },
-                { text: 'urql — React', link:'/docs/integration/client/urql.md' },
-                { text: 'Vue Apollo — Vue', link:'/docs/integration/client/vue-apollo.md' },
-                { text: 'Fetch API', link:'/docs/integration/client/fetch.md' },
-              ]
-            },
-            // { text: 'ChatGPT', link:'/docs/integration/chatgpt.md' },
-          ]
+        // logo: {
+        //   light: '/logo/r6p.svg',
+        //   dark: '/logo/r5y.svg'
+        // },
+        siteTitle: false,
+        nav: [
+            { text: 'Home', link: '/' },
+            { text: 'Docs', link: '/docs/index.md' },
+            { text: 'API', link: '/api/index.md' },
+        ],
+        socialLinks: [
+            { icon: 'github', link: 'https://github.com/stepci/garph' },
+            { icon: 'twitter', link: 'https://twitter.com/ci_step' },
+            { icon: 'discord', link: 'https://discord.gg/KqJJzJ3BTu' },
+        ],
+        editLink: {
+            pattern: 'https://github.com/stepci/garph/edit/main/www/:path',
+            text: 'Edit this page on GitHub',
         },
-        {
-          text: 'Comparisons', link: '/docs/comparisons.md',
-        }
-      ],
-    }
-  }
+        outline: [2, 3],
+        sidebar: {
+            '/docs': [
+                {
+                    text: 'Guide',
+                    items: [
+                        { text: 'Quickstart', link: '/docs/index.md' },
+                        { text: 'Schemas', link: '/docs/guide/schemas.md' },
+                        { text: 'Resolvers', link: '/docs/guide/resolvers.md' },
+                        { text: 'Loaders', link: '/docs/guide/loaders.md' },
+                        {
+                            text: 'Inferring Types',
+                            link: '/docs/guide/inferring-types.md',
+                        },
+                        {
+                            text: 'Migrate <span class="badge-new">New</span>',
+                            link: '/docs/guide/migrate.md',
+                        },
+                    ],
+                },
+                {
+                    text: 'Advanced',
+                    items: [
+                        { text: 'Auth', link: '/docs/advanced/auth.md' },
+                        { text: 'Context', link: '/docs/advanced/context.md' },
+                        {
+                            text: 'File Uploads',
+                            link: '/docs/advanced/file-uploads.md',
+                        },
+                        {
+                            text: 'Defer and Stream',
+                            link: '/docs/advanced/defer-stream.md',
+                        },
+                        {
+                            text: 'Subscriptions',
+                            link: '/docs/advanced/subscriptions.md',
+                        },
+                        {
+                            text: 'Pagination',
+                            link: '/docs/advanced/pagination.md',
+                        },
+                        { text: 'Relay', link: '/docs/advanced/relay.md' },
+                        {
+                            text: 'Validation',
+                            link: '/docs/advanced/validation.md',
+                        },
+                        {
+                            text: 'Federation',
+                            link: '/docs/advanced/federation.md',
+                        },
+                        { text: 'Errors', link: '/docs/advanced/errors.md' },
+                        { text: 'Testing', link: '/docs/advanced/testing.md' },
+                        {
+                            text: 'Extending Garph',
+                            link: '/docs/advanced/extending-garph.md',
+                        },
+                    ],
+                },
+                {
+                    text: 'Integration',
+                    items: [
+                        {
+                            text: 'Examples',
+                            collapsed: true,
+                            items: [
+                                {
+                                    text: `Next.js <small style="display: block">Yoga + GQty</small>`,
+                                    link: '/docs/integration/examples/nextjs.md',
+                                },
+                                {
+                                    text: 'Nuxt <small style="display: block">Yoga + Vue Apollo</small>',
+                                    link: '/docs/integration/examples/nuxt.md',
+                                },
+                                {
+                                    text: 'Remix <small style="display: block">Yoga + GQty</small>',
+                                    link: '/docs/integration/examples/remix.md',
+                                },
+                            ],
+                        },
+                        {
+                            text: 'Server',
+                            collapsed: true,
+                            items: [
+                                {
+                                    text: 'Yoga',
+                                    link: '/docs/integration/server/graphql-yoga.md',
+                                },
+                                {
+                                    text: 'Apollo Server',
+                                    link: '/docs/integration/server/apollo-server.md',
+                                },
+                                {
+                                    text: 'Mercurius',
+                                    link: '/docs/integration/server/mercurius.md',
+                                },
+                            ],
+                        },
+                        {
+                            text: 'Client',
+                            collapsed: true,
+                            items: [
+                                {
+                                    text: 'GQty — Universal',
+                                    link: '/docs/integration/client/gqty.md',
+                                },
+                                {
+                                    text: 'urql — React',
+                                    link: '/docs/integration/client/urql.md',
+                                },
+                                {
+                                    text: 'Vue Apollo — Vue',
+                                    link: '/docs/integration/client/vue-apollo.md',
+                                },
+                                {
+                                    text: 'Fetch API',
+                                    link: '/docs/integration/client/fetch.md',
+                                },
+                            ],
+                        },
+                        // { text: 'ChatGPT', link:'/docs/integration/chatgpt.md' },
+                    ],
+                },
+                {
+                    text: 'Comparisons',
+                    link: '/docs/comparisons.md',
+                },
+            ],
+        },
+    },
 })

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,77 +1,77 @@
 :root {
-  --vp-c-brand-1: #3230df;
-  --vp-c-brand-dark: #3230df;
-  --vp-code-block-bg: #f6f8fa;
-  --vp-c-text-1: #3f3f46;
-  --vp-c-divider: #e4e4e7;
-  --vp-code-tab-divider: var(--vp-c-divider);
-  --vp-code-tab-text-color: var(--vp-c-text-2);
-  --vp-code-tab-active-text-color: var(--vp-c-text-1);
-  --vp-code-tab-hover-text-color: var(--vp-c-text-1);
-  --vp-code-line-highlight-color: rgba(0,0,0,.05);
-  --vp-code-color: inherit
+    --vp-c-brand-1: #3230df;
+    --vp-c-brand-dark: #3230df;
+    --vp-code-block-bg: #f6f8fa;
+    --vp-c-text-1: #3f3f46;
+    --vp-c-divider: #e4e4e7;
+    --vp-code-tab-divider: var(--vp-c-divider);
+    --vp-code-tab-text-color: var(--vp-c-text-2);
+    --vp-code-tab-active-text-color: var(--vp-c-text-1);
+    --vp-code-tab-hover-text-color: var(--vp-c-text-1);
+    --vp-code-line-highlight-color: rgba(0, 0, 0, 0.05);
+    --vp-code-color: inherit;
 }
 
 .dark {
-  --vp-c-brand-1: rgb(94,92,230);
-  --vp-c-brand-dark: rgb(94,92,230);
-  --vp-c-bg-alt: #131316;
-  --vp-c-bg: #18181B;
-  --vp-code-block-bg: #0e0e10;
-  --vp-code-line-highlight-color: rgba(94,92,230, .07);
-  /* Alternative */
-  /* --vp-c-bg-alt: #000;
+    --vp-c-brand-1: rgb(94, 92, 230);
+    --vp-c-brand-dark: rgb(94, 92, 230);
+    --vp-c-bg-alt: #131316;
+    --vp-c-bg: #18181b;
+    --vp-code-block-bg: #0e0e10;
+    --vp-code-line-highlight-color: rgba(94, 92, 230, 0.07);
+    /* Alternative */
+    /* --vp-c-bg-alt: #000;
   --vp-c-bg: #000; */
-  /* Colored 0 */
-  /* --vp-c-bg-alt: #050520;
+    /* Colored 0 */
+    /* --vp-c-bg-alt: #050520;
   --vp-c-bg: #050520; */
-  /* Colored 1 */
-  /* --vp-c-bg-alt: #040317;
+    /* Colored 1 */
+    /* --vp-c-bg-alt: #040317;
   --vp-c-bg: #040317; */
-  /* Colored 2 */
-  /* --vp-c-bg-alt: #030312;
+    /* Colored 2 */
+    /* --vp-c-bg-alt: #030312;
   --vp-c-bg: #030312; */
-  /* --vp-code-block-bg: rgba(0, 0, 0, 0.15); */
-  --vp-c-divider: rgba(255, 255, 255, 0.08);
-  --vp-c-text-1: rgba(255, 255, 245, 0.86);
+    /* --vp-code-block-bg: rgba(0, 0, 0, 0.15); */
+    --vp-c-divider: rgba(255, 255, 255, 0.08);
+    --vp-c-text-1: rgba(255, 255, 245, 0.86);
 }
 
 .VPSidebar {
-  border-right: 1px solid var(--vp-c-divider)
+    border-right: 1px solid var(--vp-c-divider);
 }
 
 .vp-doc div[class*='language-'] {
-  border: 1px solid var(--vp-c-divider)
+    border: 1px solid var(--vp-c-divider);
 }
 
 .vp-code-group .tabs {
-  border: 1px solid var(--vp-c-divider);
-  border-bottom: 0;
+    border: 1px solid var(--vp-c-divider);
+    border-bottom: 0;
 }
 
 .vp-code-group div[class*='language-'] {
-  border-top: 0
+    border-top: 0;
 }
 
 code.nav {
-  border-radius: 4px;
-  padding: 3px 6px;
-  color: var(--vp-c-text-code);
-  background-color: var(--vp-c-divider);
+    border-radius: 4px;
+    padding: 3px 6px;
+    color: var(--vp-c-text-code);
+    background-color: var(--vp-c-divider);
 }
 
 .badge-new {
-  margin-left: 2px;
-  box-sizing: border-box;
-  padding: 2px 6px;
-  background-color: var(--vp-c-brand);
-  font-size: 10px;
-  color: #fff;
-  border-radius: 20px;
-  font-weight: 700;
-  text-transform: uppercase;
+    margin-left: 2px;
+    box-sizing: border-box;
+    padding: 2px 6px;
+    background-color: var(--vp-c-brand);
+    font-size: 10px;
+    color: #fff;
+    border-radius: 20px;
+    font-weight: 700;
+    text-transform: uppercase;
 }
 
 .vp-doc a {
-  text-decoration: none;
+    text-decoration: none;
 }

--- a/README.md
+++ b/README.md
@@ -26,24 +26,25 @@ Garph is a fullstack GraphQL framework for TypeScript, that aims to deliver the 
     import { createServer } from 'http'
 
     const queryType = g.type('Query', {
-      greet: g.string()
-        .args({
-          name: g.string().optional().default('Max')
-        })
-        .description('Greets a person')
+        greet: g
+            .string()
+            .args({
+                name: g.string().optional().default('Max'),
+            })
+            .description('Greets a person'),
     })
 
     const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-      Query: {
-        greet: (parent, args, context, info) => `Hello, ${args.name}`
-      }
+        Query: {
+            greet: (parent, args, context, info) => `Hello, ${args.name}`,
+        },
     }
 
     const schema = buildSchema({ g, resolvers })
     const yoga = createYoga({ schema })
     const server = createServer(yoga)
     server.listen(4000, () => {
-      console.info('Server is running on http://localhost:4000/graphql')
+        console.info('Server is running on http://localhost:4000/graphql')
     })
     ```
 
@@ -61,7 +62,7 @@ Garph is a fullstack GraphQL framework for TypeScript, that aims to deliver the 
 
     ```graphql
     {
-      greet(name: "Max")
+        greet(name: "Max")
     }
     ```
 

--- a/examples/client.ts
+++ b/examples/client.ts
@@ -2,23 +2,27 @@ import { g } from '../src'
 import { InferClient, ClientTypes } from '../src/client'
 
 const tType = g.type('Test', {
-  test: g.string().list().description('Greets a person')
+    test: g.string().list().description('Greets a person'),
 })
 
 const queryType = g.type('Query', {
-  greet: g.ref(() => tType)
-    .list()
-    .optional()
-    .args({
-      name: g.ref(() => tType).optional().default({ test: ['sdf'] }),
-    })
-    .description('Greets a person')
+    greet: g
+        .ref(() => tType)
+        .list()
+        .optional()
+        .args({
+            name: g
+                .ref(() => tType)
+                .optional()
+                .default({ test: ['sdf'] }),
+        })
+        .description('Greets a person'),
 })
 
 type x = InferClient<{ query: typeof queryType }>
 
-export function createClient <T extends ClientTypes> (): InferClient<T> {
-  return null as any
+export function createClient<T extends ClientTypes>(): InferClient<T> {
+    return null as any
 }
 
 const client = createClient<{ query: typeof queryType }>()

--- a/examples/context.ts
+++ b/examples/context.ts
@@ -3,24 +3,27 @@ import { createYoga, YogaInitialContext } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const queryType = g.type('Query', {
-  context: g.string()
+    context: g.string(),
 })
 
 const context = () => {
-  return {
-    hello: 'world'
-  }
+    return {
+        hello: 'world',
+    }
 }
 
-const resolvers: InferResolvers<{ Query: typeof queryType }, { context: YogaInitialContext & ReturnType<typeof context> }> = {
-  Query: {
-    context: (parent, args, context, info) => `Context: ${context.hello}`
-  }
+const resolvers: InferResolvers<
+    { Query: typeof queryType },
+    { context: YogaInitialContext & ReturnType<typeof context> }
+> = {
+    Query: {
+        context: (parent, args, context, info) => `Context: ${context.hello}`,
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema, context })
 const server = createServer(yoga)
 server.listen(4001, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/deferstream.ts
+++ b/examples/deferstream.ts
@@ -4,48 +4,49 @@ import { useDeferStream } from '@graphql-yoga/plugin-defer-stream'
 import { createServer } from 'node:http'
 
 const queryType = g.type('Query', {
-  alphabet: g.string().list().description(`This field can be @stream'ed`),
-  fastField: g.string().description('A field that resolves fast.'),
-  slowField: g
-    .string()
-    .optional()
-    .description(
-      'A field that resolves slowly. Maybe you want to @defer this field ;)'
-    )
-    .args({
-      waitFor: g.int().default(5000),
-    })
+    alphabet: g.string().list().description(`This field can be @stream'ed`),
+    fastField: g.string().description('A field that resolves fast.'),
+    slowField: g
+        .string()
+        .optional()
+        .description(
+            'A field that resolves slowly. Maybe you want to @defer this field ;)'
+        )
+        .args({
+            waitFor: g.int().default(5000),
+        }),
 })
 
-const wait = (time: number) => new Promise(resolve => setTimeout(resolve, time))
+const wait = (time: number) =>
+    new Promise((resolve) => setTimeout(resolve, time))
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    async *alphabet() {
-      for (const character of ['a', 'b', 'c', 'd', 'e', 'f', 'g']) {
-        yield character
-        await wait(1000)
-      }
+    Query: {
+        async *alphabet() {
+            for (const character of ['a', 'b', 'c', 'd', 'e', 'f', 'g']) {
+                yield character
+                await wait(1000)
+            }
+        },
+        fastField: async () => {
+            await wait(100)
+            return 'I am speed'
+        },
+        slowField: async (_, { waitFor }) => {
+            await wait(waitFor)
+            return 'I am slow'
+        },
     },
-    fastField: async () => {
-      await wait(100)
-      return 'I am speed'
-    },
-    slowField: async (_, { waitFor }) => {
-      await wait(waitFor)
-      return 'I am slow'
-    }
-  }
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({
-  schema,
-  plugins: [useDeferStream()]
+    schema,
+    plugins: [useDeferStream()],
 })
 
 const server = createServer(yoga)
 
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -2,43 +2,59 @@ import { g, InferResolvers, Infer, InferArgs, buildSchema } from '../src/index'
 import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
-const blogType = g.type('Blog', {
-  title: g.string(),
-  author: g.ref(() => userType).description('The author of the blog')
-}).description('The blog of the user')
+const blogType = g
+    .type('Blog', {
+        title: g.string(),
+        author: g.ref(() => userType).description('The author of the blog'),
+    })
+    .description('The blog of the user')
 
 const userType = g.type('User', {
-  age: g.int(),
-  friends: g.ref(() => userType).description('The friends of the user').list().deprecated('wow'),
+    age: g.int(),
+    friends: g
+        .ref(() => userType)
+        .description('The friends of the user')
+        .list()
+        .deprecated('wow'),
 })
 
-const scalarType = g.scalarType<Date, number>('SC', {
-  serialize: (value) => value.getTime(),
-  parseValue: (value) => new Date(value)
-}).description('The scalar type')
+const scalarType = g
+    .scalarType<Date, number>('SC', {
+        serialize: (value) => value.getTime(),
+        parseValue: (value) => new Date(value),
+    })
+    .description('The scalar type')
 
-const inputType = g.inputType('UserInput', {
-  name: g.string(),
-  age: g.int().required(),
-}).description('The input type')
+const inputType = g
+    .inputType('UserInput', {
+        name: g.string(),
+        age: g.int().required(),
+    })
+    .description('The input type')
 
 const queryType = g.type('Query', {
-  greet: g.string().args({
-    test: g.ref(() => scalarType).description('The wow').list(),
-  }).description('The greet query'),
+    greet: g
+        .string()
+        .args({
+            test: g
+                .ref(() => scalarType)
+                .description('The wow')
+                .list(),
+        })
+        .description('The greet query'),
 })
 
 type x = InferArgs<typeof queryType>
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    greet: (parent, args) => 'Hello World'
-  }
+    Query: {
+        greet: (parent, args) => 'Hello World',
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/errors.ts
+++ b/examples/errors.ts
@@ -4,24 +4,26 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const queryType = g.type('Query', {
-  error: g.string(),
-  error_extensions: g.string()
+    error: g.string(),
+    error_extensions: g.string(),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    error: () => {
-      throw new GraphQLError('Expected error')
+    Query: {
+        error: () => {
+            throw new GraphQLError('Expected error')
+        },
+        error_extensions: () => {
+            throw new GraphQLError('Expected error with extensions', {
+                extensions: { code: 'EXPECTED_ERROR' },
+            })
+        },
     },
-    error_extensions: () => {
-      throw new GraphQLError('Expected error with extensions', { extensions: { code: 'EXPECTED_ERROR' } })
-    }
-  }
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4001, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/extend.ts
+++ b/examples/extend.ts
@@ -3,43 +3,46 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const node = {
-  id: g.id()
+    id: g.id(),
 }
 
 const name = {
-  name: g.string()
+    name: g.string(),
 }
 
 const test = g.type('Test', {}).extend([node, name])
 
 const queryType = g.type('Query', {
-  test: g.ref(() => test)
+    test: g.ref(() => test),
 })
 
 type Test = Infer<typeof test>
 
-const resolvers: InferResolvers<{ Query: typeof queryType, Test: typeof test }, {}> = {
-  Query: {
-    test: (parent, args, context, info) => {
-      return {
-        id: '123',
-        name: 'Test'
-      }
-    }
-  },
-  Test: {
-    id: (parent, args, context, info) => {
-      return parent.id
+const resolvers: InferResolvers<
+    { Query: typeof queryType; Test: typeof test },
+    {}
+> = {
+    Query: {
+        test: (parent, args, context, info) => {
+            return {
+                id: '123',
+                name: 'Test',
+            }
+        },
     },
-    name: (parent, args, context, info) => {
-      return parent.name
-    }
-  }
+    Test: {
+        id: (parent, args, context, info) => {
+            return parent.id
+        },
+        name: (parent, args, context, info) => {
+            return parent.name
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/implements.ts
+++ b/examples/implements.ts
@@ -3,41 +3,44 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const node = g.interface('Node', {
-  id: g.id()
+    id: g.id(),
 })
 
 const name = g.interface('Name', {
-  name: g.string()
+    name: g.string(),
 })
 
 const test = g.type('Test', {}).implements([node, name])
 
 const queryType = g.type('Query', {
-  test: g.ref(() => test)
+    test: g.ref(() => test),
 })
 
-const resolvers: InferResolvers<{ Query: typeof queryType, Test: typeof test }, {}> = {
-  Query: {
-    test: (parent, args, context, info) => {
-      return {
-        id: '123',
-        name: 'Test'
-      }
-    }
-  },
-  Test: {
-    id: (parent, args, context, info) => {
-      return parent.id
+const resolvers: InferResolvers<
+    { Query: typeof queryType; Test: typeof test },
+    {}
+> = {
+    Query: {
+        test: (parent, args, context, info) => {
+            return {
+                id: '123',
+                name: 'Test',
+            }
+        },
     },
-    name: (parent, args, context, info) => {
-      return parent.name
-    }
-  }
+    Test: {
+        id: (parent, args, context, info) => {
+            return parent.id
+        },
+        name: (parent, args, context, info) => {
+            return parent.name
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/loader.ts
+++ b/examples/loader.ts
@@ -3,50 +3,56 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const Dog = g.type('Dog', {
-  name: g.string(),
-  owner: g.string().omitResolver()
+    name: g.string(),
+    owner: g.string().omitResolver(),
 })
 
 const queryType = g.type('Query', {
-  dogs: g.ref(() => Dog).list()
+    dogs: g.ref(() => Dog).list(),
 })
 
 const owners = {
-  Apollo: 'Mish',
-  Buddy: 'Sebastian'
+    Apollo: 'Mish',
+    Buddy: 'Sebastian',
 }
 
-type resolverTypes = InferResolvers<{ Query: typeof queryType, Dog: typeof Dog }, {}>
+type resolverTypes = InferResolvers<
+    { Query: typeof queryType; Dog: typeof Dog },
+    {}
+>
 
 const resolvers: resolverTypes = {
-  Query: {
-    dogs: (parent, args, context, info) => {
-      return [
-        {
-          name: 'Apollo',
+    Query: {
+        dogs: (parent, args, context, info) => {
+            return [
+                {
+                    name: 'Apollo',
+                },
+                {
+                    name: 'Buddy',
+                },
+            ]
         },
-        {
-          name: 'Buddy',
-        }
-      ]
-    }
-  },
-  Dog: {
-    owner: {
-      load (queries) {
-        return queries.map(q => new Promise(resolve => {
-          setTimeout(() => {
-            resolve(owners[q.parent.name])
-          }, 1000)
-        }))
-      }
-    }
-  }
+    },
+    Dog: {
+        owner: {
+            load(queries) {
+                return queries.map(
+                    (q) =>
+                        new Promise((resolve) => {
+                            setTimeout(() => {
+                                resolve(owners[q.parent.name])
+                            }, 1000)
+                        })
+                )
+            },
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/pagination.ts
+++ b/examples/pagination.ts
@@ -3,43 +3,46 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const user = g.type('User', {
-  id: g.string().description('User ID'),
-  name: g.string().description('User name'),
+    id: g.string().description('User ID'),
+    name: g.string().description('User name'),
 })
 
 const queryType = g.type('Query', {
-  users: g.ref(user).paginatedList().args({ ...g.pageInfoArgs })
+    users: g
+        .ref(user)
+        .paginatedList()
+        .args({ ...g.pageInfoArgs }),
 })
 
 type QueryType = Infer<typeof queryType>
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    users: (parent, args, context, info) => {
-      return {
-        edges: [
-          {
-            node: {
-              id: '1',
-              name: 'John',
-            },
-            cursor: '1',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '1',
-          endCursor: '1',
-        }
-      }
+    Query: {
+        users: (parent, args, context, info) => {
+            return {
+                edges: [
+                    {
+                        node: {
+                            id: '1',
+                            name: 'John',
+                        },
+                        cursor: '1',
+                    },
+                ],
+                pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: '1',
+                    endCursor: '1',
+                },
+            }
+        },
     },
-  }
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/promo.ts
+++ b/examples/promo.ts
@@ -3,24 +3,25 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const queryType = g.type('Query', {
-  greet: g.string()
-    .args({
-      name: g.string().optional().default('Max'),
-    })
-    .description('Greets a person')
+    greet: g
+        .string()
+        .args({
+            name: g.string().optional().default('Max'),
+        })
+        .description('Greets a person'),
 })
 
 type QueryType = Infer<typeof queryType>
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    greet: (parent, args, context, info) => `Hello, ${args.name}`
-  }
+    Query: {
+        greet: (parent, args, context, info) => `Hello, ${args.name}`,
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/relay.ts
+++ b/examples/relay.ts
@@ -3,43 +3,49 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const user = g.node('UserNode', {
-  name: g.string().description('User name'),
+    name: g.string().description('User name'),
 })
 
-const userEdge = g.edge('UserEdge', g.ref(() => user))
-const userConnection = g.connection('UserConnection', g.ref(() => userEdge))
+const userEdge = g.edge(
+    'UserEdge',
+    g.ref(() => user)
+)
+const userConnection = g.connection(
+    'UserConnection',
+    g.ref(() => userEdge)
+)
 
 const queryType = g.type('Query', {
-  users: g.ref(userConnection).args({ ...g.pageInfoArgs })
+    users: g.ref(userConnection).args({ ...g.pageInfoArgs }),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    users: (parent, args, context, info) => {
-      return {
-        edges: [
-          {
-            node: {
-              id: '1',
-              name: 'John',
-            },
-            cursor: '1',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '1',
-          endCursor: '1',
-        }
-      }
-    }
-  }
+    Query: {
+        users: (parent, args, context, info) => {
+            return {
+                edges: [
+                    {
+                        node: {
+                            id: '1',
+                            name: 'John',
+                        },
+                        cursor: '1',
+                    },
+                ],
+                pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: '1',
+                    endCursor: '1',
+                },
+            }
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/scalars.ts
+++ b/examples/scalars.ts
@@ -5,18 +5,18 @@ import { createServer } from 'http'
 const date = g.scalarType<Date, string>('Test')
 
 const queryType = g.type('Query', {
-  today: date
+    today: date,
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    today: () => new Date()
-  }
+    Query: {
+        today: () => new Date(),
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/subscriptions.ts
+++ b/examples/subscriptions.ts
@@ -3,29 +3,32 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const queryType = g.type('Query', {
-  greet: g.string()
+    greet: g.string(),
 })
 
 const subscriptionType = g.type('Subscription', {
-  counter: g.int()
+    counter: g.int(),
 })
 
-const resolvers: InferResolvers<{ Subscription: typeof subscriptionType }, {}> = {
-  Subscription: {
-    counter: {
-      subscribe: async function* (parent, args, context, info) {
-        for (let i = 100; i >= 0; i--) {
-          await new Promise((resolve) => setTimeout(resolve, 1000))
-          yield { counter: i }
-        }
-      }
+const resolvers: InferResolvers<{ Subscription: typeof subscriptionType }, {}> =
+    {
+        Subscription: {
+            counter: {
+                subscribe: async function* (parent, args, context, info) {
+                    for (let i = 100; i >= 0; i--) {
+                        await new Promise((resolve) =>
+                            setTimeout(resolve, 1000)
+                        )
+                        yield { counter: i }
+                    }
+                },
+            },
+        },
     }
-  }
-}
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/union.ts
+++ b/examples/union.ts
@@ -3,46 +3,50 @@ import { createYoga } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const x = g.type('X', {
-  a: g.string(),
+    a: g.string(),
 })
 
 const y = g.type('Y', {
-  b: g.string(),
+    b: g.string(),
 })
 
 const union = g.unionType('Union', { x, y })
 type Union = Infer<typeof union>
 
 const queryType = g.type('Query', {
-  greet: g.ref(() => union)
-    .args({
-      name: g.string().optional().default('Max'),
-    })
-    .description('Greets a person')
+    greet: g
+        .ref(() => union)
+        .args({
+            name: g.string().optional().default('Max'),
+        })
+        .description('Greets a person'),
 })
 
 type Query = Infer<typeof queryType>
 
-const resolvers: InferResolvers<{ Query: typeof queryType, Union: typeof union }, {}> = {
-  Query: {
-    greet: (parent, args, context, info) => {
-      if (args.name === 'Max') {
-        return { __typename: 'X', a: 'Hello Max' }
-      } else {
-        return { __typename: 'Y', b: 'Hello World' }
-      }
-    }
-  },
-  Union: {
-    __resolveType: (parent, context, info) => {
-      return parent.__typename
-    }
-  }
+const resolvers: InferResolvers<
+    { Query: typeof queryType; Union: typeof union },
+    {}
+> = {
+    Query: {
+        greet: (parent, args, context, info) => {
+            if (args.name === 'Max') {
+                return { __typename: 'X', a: 'Hello Max' }
+            } else {
+                return { __typename: 'Y', b: 'Hello World' }
+            }
+        },
+    },
+    Union: {
+        __resolveType: (parent, context, info) => {
+            return parent.__typename
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/uploads.ts
+++ b/examples/uploads.ts
@@ -5,25 +5,26 @@ import { createServer } from 'http'
 const file = g.scalarType<File, never>('File')
 
 const mutationType = g.type('Mutation', {
-  readTextFile: g.string()
-    .args({
-      file: g.ref(file),
-    })
-    .description('Greets a person')
+    readTextFile: g
+        .string()
+        .args({
+            file: g.ref(file),
+        })
+        .description('Greets a person'),
 })
 
 const resolvers: InferResolvers<{ Mutation: typeof mutationType }, {}> = {
-  Mutation: {
-    readTextFile: async (parent, { file }, context, info) => {
-      const textContent = await file.text()
-      return textContent
-    }
-  }
+    Mutation: {
+        readTextFile: async (parent, { file }, context, info) => {
+            const textContent = await file.text()
+            return textContent
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/examples/validation.ts
+++ b/examples/validation.ts
@@ -4,29 +4,31 @@ import { GraphQLError } from 'graphql'
 import { createServer } from 'http'
 
 const username = g.scalarType<string, string>('Username', {
-  serialize: (username) => username,
-  parseValue: (username) => {
-    if (username.length < 3) {
-      throw new GraphQLError('Username must be at least 3 characters long')
-    }
+    serialize: (username) => username,
+    parseValue: (username) => {
+        if (username.length < 3) {
+            throw new GraphQLError(
+                'Username must be at least 3 characters long'
+            )
+        }
 
-    return username
-  }
+        return username
+    },
 })
 
 const queryType = g.type('Query', {
-  login: g.string().args({ username }),
+    login: g.string().args({ username }),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    login: (parent, args) => 'Success!'
-  }
+    Query: {
+        login: (parent, args) => 'Success!',
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({ schema })
 const server = createServer(yoga)
 server.listen(4001, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3272 +1,3294 @@
 {
-  "name": "garph",
-  "version": "0.6.4",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "garph",
-      "version": "0.6.4",
-      "license": "MIT",
-      "dependencies": {
-        "graphql-compose": "^9.0.10",
-        "single-user-cache": "^0.6.0"
-      },
-      "devDependencies": {
-        "@graphql-yoga/plugin-defer-stream": "^2.0.4",
-        "graphql": "^16.6.0",
-        "graphql-yoga": "^4.0.4",
-        "ts-node": "^10.9.1",
-        "typedoc": "^0.23.27",
-        "typedoc-plugin-markdown": "^3.14.0",
-        "typescript": "^4.9.5",
-        "vitepress": "^1.0.0-rc.15"
-      }
-    },
-    "node_modules/@algolia/autocomplete-core": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
-      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
-        "@algolia/autocomplete-shared": "1.9.3"
-      }
-    },
-    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
-      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.9.3"
-      },
-      "peerDependencies": {
-        "search-insights": ">= 1 < 3"
-      }
-    },
-    "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
-      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.9.3"
-      },
-      "peerDependencies": {
-        "@algolia/client-search": ">= 4.9.1 < 6",
-        "algoliasearch": ">= 4.9.1 < 6"
-      }
-    },
-    "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
-      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
-      "dev": true,
-      "peerDependencies": {
-        "@algolia/client-search": ">= 4.9.1 < 6",
-        "algoliasearch": ">= 4.9.1 < 6"
-      }
-    },
-    "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz",
-      "integrity": "sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/cache-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.20.0.tgz",
-      "integrity": "sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==",
-      "dev": true
-    },
-    "node_modules/@algolia/cache-in-memory": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz",
-      "integrity": "sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/client-account": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.20.0.tgz",
-      "integrity": "sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.20.0.tgz",
-      "integrity": "sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.20.0.tgz",
-      "integrity": "sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.20.0.tgz",
-      "integrity": "sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.20.0.tgz",
-      "integrity": "sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/logger-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.20.0.tgz",
-      "integrity": "sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==",
-      "dev": true
-    },
-    "node_modules/@algolia/logger-console": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.20.0.tgz",
-      "integrity": "sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/logger-common": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz",
-      "integrity": "sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/requester-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.20.0.tgz",
-      "integrity": "sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==",
-      "dev": true
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz",
-      "integrity": "sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/requester-common": "4.20.0"
-      }
-    },
-    "node_modules/@algolia/transporter": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.20.0.tgz",
-      "integrity": "sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.22.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@docsearch/css": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
-      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
-      "dev": true
-    },
-    "node_modules/@docsearch/js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.2.tgz",
-      "integrity": "sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==",
-      "dev": true,
-      "dependencies": {
-        "@docsearch/react": "3.5.2",
-        "preact": "^10.0.0"
-      }
-    },
-    "node_modules/@docsearch/react": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
-      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/autocomplete-core": "1.9.3",
-        "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.5.2",
-        "algoliasearch": "^4.19.1"
-      },
-      "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 19.0.0",
-        "react": ">= 16.8.0 < 19.0.0",
-        "react-dom": ">= 16.8.0 < 19.0.0",
-        "search-insights": ">= 1 < 3"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
+    "name": "garph",
+    "version": "0.6.4",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "garph",
+            "version": "0.6.4",
+            "license": "MIT",
+            "dependencies": {
+                "graphql-compose": "^9.0.10",
+                "single-user-cache": "^0.6.0"
+            },
+            "devDependencies": {
+                "@graphql-yoga/plugin-defer-stream": "^2.0.4",
+                "graphql": "^16.6.0",
+                "graphql-yoga": "^4.0.4",
+                "prettier": "^3.1.1",
+                "ts-node": "^10.9.1",
+                "typedoc": "^0.23.27",
+                "typedoc-plugin-markdown": "^3.14.0",
+                "typescript": "^4.9.5",
+                "vitepress": "^1.0.0-rc.15"
+            }
         },
-        "react": {
-          "optional": true
+        "node_modules/@algolia/autocomplete-core": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+            "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+                "@algolia/autocomplete-shared": "1.9.3"
+            }
         },
-        "react-dom": {
-          "optional": true
+        "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+            "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/autocomplete-shared": "1.9.3"
+            },
+            "peerDependencies": {
+                "search-insights": ">= 1 < 3"
+            }
         },
-        "search-insights": {
-          "optional": true
+        "node_modules/@algolia/autocomplete-preset-algolia": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+            "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/autocomplete-shared": "1.9.3"
+            },
+            "peerDependencies": {
+                "@algolia/client-search": ">= 4.9.1 < 6",
+                "algoliasearch": ">= 4.9.1 < 6"
+            }
+        },
+        "node_modules/@algolia/autocomplete-shared": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+            "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+            "dev": true,
+            "peerDependencies": {
+                "@algolia/client-search": ">= 4.9.1 < 6",
+                "algoliasearch": ">= 4.9.1 < 6"
+            }
+        },
+        "node_modules/@algolia/cache-browser-local-storage": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz",
+            "integrity": "sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/cache-common": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/cache-common": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.20.0.tgz",
+            "integrity": "sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==",
+            "dev": true
+        },
+        "node_modules/@algolia/cache-in-memory": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz",
+            "integrity": "sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/cache-common": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/client-account": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.20.0.tgz",
+            "integrity": "sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/client-common": "4.20.0",
+                "@algolia/client-search": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/client-analytics": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.20.0.tgz",
+            "integrity": "sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/client-common": "4.20.0",
+                "@algolia/client-search": "4.20.0",
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/client-common": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.20.0.tgz",
+            "integrity": "sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/client-personalization": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.20.0.tgz",
+            "integrity": "sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/client-common": "4.20.0",
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/client-search": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.20.0.tgz",
+            "integrity": "sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/client-common": "4.20.0",
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/logger-common": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.20.0.tgz",
+            "integrity": "sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==",
+            "dev": true
+        },
+        "node_modules/@algolia/logger-console": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.20.0.tgz",
+            "integrity": "sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/logger-common": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/requester-browser-xhr": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz",
+            "integrity": "sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/requester-common": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/requester-common": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.20.0.tgz",
+            "integrity": "sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==",
+            "dev": true
+        },
+        "node_modules/@algolia/requester-node-http": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz",
+            "integrity": "sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/requester-common": "4.20.0"
+            }
+        },
+        "node_modules/@algolia/transporter": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.20.0.tgz",
+            "integrity": "sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/cache-common": "4.20.0",
+                "@algolia/logger-common": "4.20.0",
+                "@algolia/requester-common": "4.20.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.22.16",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
+            "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@docsearch/css": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+            "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
+            "dev": true
+        },
+        "node_modules/@docsearch/js": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.2.tgz",
+            "integrity": "sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==",
+            "dev": true,
+            "dependencies": {
+                "@docsearch/react": "3.5.2",
+                "preact": "^10.0.0"
+            }
+        },
+        "node_modules/@docsearch/react": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+            "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/autocomplete-core": "1.9.3",
+                "@algolia/autocomplete-preset-algolia": "1.9.3",
+                "@docsearch/css": "3.5.2",
+                "algoliasearch": "^4.19.1"
+            },
+            "peerDependencies": {
+                "@types/react": ">= 16.8.0 < 19.0.0",
+                "react": ">= 16.8.0 < 19.0.0",
+                "react-dom": ">= 16.8.0 < 19.0.0",
+                "search-insights": ">= 1 < 3"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                },
+                "search-insights": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@envelop/core": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@envelop/core/-/core-4.0.1.tgz",
+            "integrity": "sha512-uBLI7ql3hZopz7vMi9UDAb9HWzKw4STKiqg4QT+lb+tu5ZNaeuJ4fom2rrmgITz38B85QZOhZrGyVrlJXxfDzw==",
+            "dev": true,
+            "dependencies": {
+                "@envelop/types": "4.0.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@envelop/types": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@envelop/types/-/types-4.0.1.tgz",
+            "integrity": "sha512-ULo27/doEsP7uUhm2iTnElx13qTO6I5FKvmLoX41cpfuw8x6e0NUFknoqhEsLzAbgz8xVS5mjwcxGCXh4lDYzg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@graphql-tools/executor": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.0.tgz",
+            "integrity": "sha512-SKlIcMA71Dha5JnEWlw4XxcaJ+YupuXg0QCZgl2TOLFz4SkGCwU/geAsJvUJFwK2RbVLpQv/UMq67lOaBuwDtg==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-typed-document-node/core": "3.2.0",
+                "@repeaterjs/repeater": "^3.0.4",
+                "tslib": "^2.4.0",
+                "value-or-promise": "^1.0.12"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/merge": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
+            "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^10.0.0",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/schema": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
+            "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/merge": "^9.0.0",
+                "@graphql-tools/utils": "^10.0.0",
+                "tslib": "^2.4.0",
+                "value-or-promise": "^1.0.12"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-tools/utils": {
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.6.tgz",
+            "integrity": "sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "dset": "^3.1.2",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-typed-document-node/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+            "dev": true,
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@graphql-yoga/logger": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/logger/-/logger-1.0.0.tgz",
+            "integrity": "sha512-JYoxwnPggH2BfO+dWlWZkDeFhyFZqaTRGLvFhy+Pjp2UxitEW6nDrw+pEDw/K9tJwMjIFMmTT9VfTqrnESmBHg==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.5.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@graphql-yoga/plugin-defer-stream": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/plugin-defer-stream/-/plugin-defer-stream-2.0.4.tgz",
+            "integrity": "sha512-VW59oqldg/9lZOEJrS/D4JQL3M5ARZD3TqUXrGKMAJdmvraZpQ11I+A3ZKLvnznT5Wcoqne6NemEjsD/eB0DKA==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-tools/utils": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^15.2.0 || ^16.0.0",
+                "graphql-yoga": "^4.0.4"
+            }
+        },
+        "node_modules/@graphql-yoga/subscription": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-4.0.0.tgz",
+            "integrity": "sha512-0qsN/BPPZNMoC2CZ8i+P6PgiJyHh1H35aKDt37qARBDaIOKDQuvEOq7+4txUKElcmXi7DYFo109FkhSQoEajrg==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-yoga/typed-event-target": "^2.0.0",
+                "@repeaterjs/repeater": "^3.0.4",
+                "@whatwg-node/events": "^0.1.0",
+                "tslib": "^2.5.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@graphql-yoga/typed-event-target": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/typed-event-target/-/typed-event-target-2.0.0.tgz",
+            "integrity": "sha512-oA/VGxGmaSDym1glOHrltw43qZsFwLLjBwvh57B79UKX/vo3+UQcRgOyE44c5RP7DCYjkrC2tuArZmb6jCzysw==",
+            "dev": true,
+            "dependencies": {
+                "@repeaterjs/repeater": "^3.0.4",
+                "tslib": "^2.5.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true,
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "node_modules/@repeaterjs/repeater": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
+            "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "node_modules/@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "dev": true
+        },
+        "node_modules/@types/node": {
+            "version": "18.14.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+            "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/@types/web-bluetooth": {
+            "version": "0.0.17",
+            "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
+            "integrity": "sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==",
+            "dev": true
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.21.3",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+            "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
+            "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.20.15",
+                "@vue/compiler-core": "3.3.4",
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/compiler-ssr": "3.3.4",
+                "@vue/reactivity-transform": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.0",
+                "postcss": "^8.1.10",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
+            "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/@vue/devtools-api": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
+            "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==",
+            "dev": true
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
+            "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+            "dev": true,
+            "dependencies": {
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/@vue/reactivity-transform": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
+            "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.20.15",
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.0"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
+            "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+            "dev": true,
+            "dependencies": {
+                "@vue/reactivity": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
+            "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+            "dev": true,
+            "dependencies": {
+                "@vue/runtime-core": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "csstype": "^3.1.1"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
+            "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-ssr": "3.3.4",
+                "@vue/shared": "3.3.4"
+            },
+            "peerDependencies": {
+                "vue": "3.3.4"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "dev": true
+        },
+        "node_modules/@vueuse/core": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.4.1.tgz",
+            "integrity": "sha512-DkHIfMIoSIBjMgRRvdIvxsyboRZQmImofLyOHADqiVbQVilP8VVHDhBX2ZqoItOgu7dWa8oXiNnScOdPLhdEXg==",
+            "dev": true,
+            "dependencies": {
+                "@types/web-bluetooth": "^0.0.17",
+                "@vueuse/metadata": "10.4.1",
+                "@vueuse/shared": "10.4.1",
+                "vue-demi": ">=0.14.5"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@vueuse/core/node_modules/vue-demi": {
+            "version": "0.14.6",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+            "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vueuse/integrations": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.4.1.tgz",
+            "integrity": "sha512-uRBPyG5Lxoh1A/J+boiioPT3ELEAPEo4t8W6Mr4yTKIQBeW/FcbsotZNPr4k9uz+3QEksMmflWloS9wCnypM7g==",
+            "dev": true,
+            "dependencies": {
+                "@vueuse/core": "10.4.1",
+                "@vueuse/shared": "10.4.1",
+                "vue-demi": ">=0.14.5"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "async-validator": "*",
+                "axios": "*",
+                "change-case": "*",
+                "drauu": "*",
+                "focus-trap": "*",
+                "fuse.js": "*",
+                "idb-keyval": "*",
+                "jwt-decode": "*",
+                "nprogress": "*",
+                "qrcode": "*",
+                "sortablejs": "*",
+                "universal-cookie": "*"
+            },
+            "peerDependenciesMeta": {
+                "async-validator": {
+                    "optional": true
+                },
+                "axios": {
+                    "optional": true
+                },
+                "change-case": {
+                    "optional": true
+                },
+                "drauu": {
+                    "optional": true
+                },
+                "focus-trap": {
+                    "optional": true
+                },
+                "fuse.js": {
+                    "optional": true
+                },
+                "idb-keyval": {
+                    "optional": true
+                },
+                "jwt-decode": {
+                    "optional": true
+                },
+                "nprogress": {
+                    "optional": true
+                },
+                "qrcode": {
+                    "optional": true
+                },
+                "sortablejs": {
+                    "optional": true
+                },
+                "universal-cookie": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vueuse/integrations/node_modules/vue-demi": {
+            "version": "0.14.6",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+            "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vueuse/metadata": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.4.1.tgz",
+            "integrity": "sha512-2Sc8X+iVzeuMGHr6O2j4gv/zxvQGGOYETYXEc41h0iZXIRnRbJZGmY/QP8dvzqUelf8vg0p/yEA5VpCEu+WpZg==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@vueuse/shared": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.4.1.tgz",
+            "integrity": "sha512-vz5hbAM4qA0lDKmcr2y3pPdU+2EVw/yzfRsBdu+6+USGa4PxqSQRYIUC9/NcT06y+ZgaTsyURw2I9qOFaaXHAg==",
+            "dev": true,
+            "dependencies": {
+                "vue-demi": ">=0.14.5"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@vueuse/shared/node_modules/vue-demi": {
+            "version": "0.14.6",
+            "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+            "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "vue-demi-fix": "bin/vue-demi-fix.js",
+                "vue-demi-switch": "bin/vue-demi-switch.js"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vue/composition-api": "^1.0.0-rc.1",
+                "vue": "^3.0.0-0 || ^2.6.0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/composition-api": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@whatwg-node/events": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+            "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/fetch": {
+            "version": "0.9.13",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.13.tgz",
+            "integrity": "sha512-PPtMwhjtS96XROnSpowCQM85gCUG2m7AXZFw0PZlGbhzx2GK7f2iOXilfgIJ0uSlCuuGbOIzfouISkA7C4FJOw==",
+            "dev": true,
+            "dependencies": {
+                "@whatwg-node/node-fetch": "^0.4.17",
+                "urlpattern-polyfill": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/node-fetch": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.19.tgz",
+            "integrity": "sha512-AW7/m2AuweAoSXmESrYQr/KBafueScNbn2iNO0u6xFr2JZdPmYsSm5yvAXYk6yDLv+eDmSSKrf7JnFZ0CsJIdA==",
+            "dev": true,
+            "dependencies": {
+                "@whatwg-node/events": "^0.1.0",
+                "busboy": "^1.6.0",
+                "fast-querystring": "^1.1.1",
+                "fast-url-parser": "^1.1.3",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@whatwg-node/server": {
+            "version": "0.9.14",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.14.tgz",
+            "integrity": "sha512-I8TT0NoCP+xThLBuGlU6dgq5wpExkphNMo2geZwQW0vAmEPtc3MNMZMIYqg5GyNmpv5Nf7fnxb8tVOIHbDvuDA==",
+            "dev": true,
+            "dependencies": {
+                "@whatwg-node/fetch": "^0.9.10",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+            "dev": true,
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/algoliasearch": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.20.0.tgz",
+            "integrity": "sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==",
+            "dev": true,
+            "dependencies": {
+                "@algolia/cache-browser-local-storage": "4.20.0",
+                "@algolia/cache-common": "4.20.0",
+                "@algolia/cache-in-memory": "4.20.0",
+                "@algolia/client-account": "4.20.0",
+                "@algolia/client-analytics": "4.20.0",
+                "@algolia/client-common": "4.20.0",
+                "@algolia/client-personalization": "4.20.0",
+                "@algolia/client-search": "4.20.0",
+                "@algolia/logger-common": "4.20.0",
+                "@algolia/logger-console": "4.20.0",
+                "@algolia/requester-browser-xhr": "4.20.0",
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/requester-node-http": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "node_modules/ansi-sequence-parser": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+            "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+            "dev": true
+        },
+        "node_modules/arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "dev": true,
+            "dependencies": {
+                "streamsearch": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.16.0"
+            }
+        },
+        "node_modules/create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
+        },
+        "node_modules/csstype": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+            "dev": true
+        },
+        "node_modules/diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dset": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+            "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/android-arm": "0.18.20",
+                "@esbuild/android-arm64": "0.18.20",
+                "@esbuild/android-x64": "0.18.20",
+                "@esbuild/darwin-arm64": "0.18.20",
+                "@esbuild/darwin-x64": "0.18.20",
+                "@esbuild/freebsd-arm64": "0.18.20",
+                "@esbuild/freebsd-x64": "0.18.20",
+                "@esbuild/linux-arm": "0.18.20",
+                "@esbuild/linux-arm64": "0.18.20",
+                "@esbuild/linux-ia32": "0.18.20",
+                "@esbuild/linux-loong64": "0.18.20",
+                "@esbuild/linux-mips64el": "0.18.20",
+                "@esbuild/linux-ppc64": "0.18.20",
+                "@esbuild/linux-riscv64": "0.18.20",
+                "@esbuild/linux-s390x": "0.18.20",
+                "@esbuild/linux-x64": "0.18.20",
+                "@esbuild/netbsd-x64": "0.18.20",
+                "@esbuild/openbsd-x64": "0.18.20",
+                "@esbuild/sunos-x64": "0.18.20",
+                "@esbuild/win32-arm64": "0.18.20",
+                "@esbuild/win32-ia32": "0.18.20",
+                "@esbuild/win32-x64": "0.18.20"
+            }
+        },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
+        "node_modules/fast-decode-uri-component": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+            "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+            "dev": true
+        },
+        "node_modules/fast-querystring": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+            "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+            "dev": true,
+            "dependencies": {
+                "fast-decode-uri-component": "^1.0.1"
+            }
+        },
+        "node_modules/fast-url-parser": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+            "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+            "dev": true,
+            "dependencies": {
+                "punycode": "^1.3.2"
+            }
+        },
+        "node_modules/focus-trap": {
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+            "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+            "dev": true,
+            "dependencies": {
+                "tabbable": "^6.2.0"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/graphql": {
+            "version": "16.6.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+            "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+            "engines": {
+                "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+            }
+        },
+        "node_modules/graphql-compose": {
+            "version": "9.0.10",
+            "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-9.0.10.tgz",
+            "integrity": "sha512-UsVoxfi2+c8WbHl2pEB+teoRRZoY4mbWBoijeLDGpAZBSPChnqtSRjp+T9UcouLCwGr5ooNyOQLoI3OVzU1bPQ==",
+            "dependencies": {
+                "graphql-type-json": "0.3.2"
+            }
+        },
+        "node_modules/graphql-type-json": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
+            "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
+            "peerDependencies": {
+                "graphql": ">=0.8.0"
+            }
+        },
+        "node_modules/graphql-yoga": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-4.0.4.tgz",
+            "integrity": "sha512-MvCLhFecYNIKuxAZisPjpIL9lxRYbpgPSNKENDO/8CV3oiFlsLJHZb5dp2sVAeLafXHeZ9TgkijLthUBc1+Jag==",
+            "dev": true,
+            "dependencies": {
+                "@envelop/core": "^4.0.0",
+                "@graphql-tools/executor": "^1.0.0",
+                "@graphql-tools/schema": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-yoga/logger": "^1.0.0",
+                "@graphql-yoga/subscription": "^4.0.0",
+                "@whatwg-node/fetch": "^0.9.7",
+                "@whatwg-node/server": "^0.9.1",
+                "dset": "^3.1.1",
+                "lru-cache": "^10.0.0",
+                "tslib": "^2.5.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "graphql": "^15.2.0 || ^16.0.0"
+            }
+        },
+        "node_modules/handlebars": {
+            "version": "4.7.7",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+            "dev": true,
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "wordwrap": "^1.0.0"
+            },
+            "bin": {
+                "handlebars": "bin/handlebars"
+            },
+            "engines": {
+                "node": ">=0.4.7"
+            },
+            "optionalDependencies": {
+                "uglify-js": "^3.1.4"
+            }
+        },
+        "node_modules/jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
+        },
+        "node_modules/lru-cache": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+            "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+            "dev": true,
+            "engines": {
+                "node": "14 || >=16.14"
+            }
+        },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
+            "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
+        "node_modules/mark.js": {
+            "version": "8.11.1",
+            "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+            "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+            "dev": true
+        },
+        "node_modules/marked": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+            "dev": true,
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
+            "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/minisearch": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.1.0.tgz",
+            "integrity": "sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg==",
+            "dev": true
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
+        },
+        "node_modules/picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
+        },
+        "node_modules/postcss": {
+            "version": "8.4.30",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
+            "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "dependencies": {
+                "nanoid": "^3.3.6",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/preact": {
+            "version": "10.17.1",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
+            "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA==",
+            "dev": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/preact"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+            "dev": true
+        },
+        "node_modules/rollup": {
+            "version": "3.29.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.2.tgz",
+            "integrity": "sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==",
+            "dev": true,
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=14.18.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/safe-stable-stringify": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+            "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/search-insights": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.2.tgz",
+            "integrity": "sha512-PxA9M5Q2bpBelVvJ3oDZR8nuY00Z6qwOxL53wNpgzV28M/D6u9WUbImDckjLSILBF8F1hn/mgyuUaOPtjow4Qw==",
+            "dev": true,
+            "peer": true
+        },
+        "node_modules/shiki": {
+            "version": "0.14.4",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
+            "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
+            }
+        },
+        "node_modules/single-user-cache": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/single-user-cache/-/single-user-cache-0.6.0.tgz",
+            "integrity": "sha512-uMrANoiybpbsrVDbZ2M7GPzxeqZiirwkVnsDAre1zGhXAAw+2dImTxu7h0l1sIVtwGeJnVsRxgG4I5rZrUX0rw==",
+            "dependencies": {
+                "safe-stable-stringify": "^2.0.0"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/tabbable": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+            "dev": true
+        },
+        "node_modules/ts-node": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+            "dev": true,
+            "dependencies": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            },
+            "bin": {
+                "ts-node": "dist/bin.js",
+                "ts-node-cwd": "dist/bin-cwd.js",
+                "ts-node-esm": "dist/bin-esm.js",
+                "ts-node-script": "dist/bin-script.js",
+                "ts-node-transpile-only": "dist/bin-transpile.js",
+                "ts-script": "dist/bin-script-deprecated.js"
+            },
+            "peerDependencies": {
+                "@swc/core": ">=1.2.50",
+                "@swc/wasm": ">=1.2.50",
+                "@types/node": "*",
+                "typescript": ">=2.7"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "@swc/wasm": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "dev": true
+        },
+        "node_modules/typedoc": {
+            "version": "0.23.28",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+            "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+            "dev": true,
+            "dependencies": {
+                "lunr": "^2.3.9",
+                "marked": "^4.2.12",
+                "minimatch": "^7.1.3",
+                "shiki": "^0.14.1"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 14.14"
+            },
+            "peerDependencies": {
+                "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
+            }
+        },
+        "node_modules/typedoc-plugin-markdown": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
+            "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
+            "dev": true,
+            "dependencies": {
+                "handlebars": "^4.7.7"
+            },
+            "peerDependencies": {
+                "typedoc": ">=0.23.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/uglify-js": {
+            "version": "3.17.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "dev": true,
+            "optional": true,
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/urlpattern-polyfill": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "dev": true
+        },
+        "node_modules/v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
+        },
+        "node_modules/value-or-promise": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+            "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite": {
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+            "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "^0.18.10",
+                "postcss": "^8.4.27",
+                "rollup": "^3.27.1"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            },
+            "peerDependencies": {
+                "@types/node": ">= 14",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitepress": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.15.tgz",
+            "integrity": "sha512-5criiHoEibkT/du7t6wQ2xQVsuTNuirQZbMAi0M9Hp0YzJoJvEX68Ej9p2PtNC84bYb/CxAh5QkMtMutk03lHw==",
+            "dev": true,
+            "dependencies": {
+                "@docsearch/css": "^3.5.2",
+                "@docsearch/js": "^3.5.2",
+                "@vue/devtools-api": "^6.5.0",
+                "@vueuse/core": "^10.4.1",
+                "@vueuse/integrations": "^10.4.1",
+                "focus-trap": "^7.5.2",
+                "mark.js": "8.11.1",
+                "minisearch": "^6.1.0",
+                "shiki": "^0.14.4",
+                "vite": "^4.4.9",
+                "vue": "^3.3.4"
+            },
+            "bin": {
+                "vitepress": "bin/vitepress.js"
+            },
+            "peerDependencies": {
+                "markdown-it-mathjax3": "^4.3.2"
+            },
+            "peerDependenciesMeta": {
+                "markdown-it-mathjax3": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+            "dev": true
+        },
+        "node_modules/vscode-textmate": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+            "dev": true
+        },
+        "node_modules/vue": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
+            "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/compiler-sfc": "3.3.4",
+                "@vue/runtime-dom": "3.3.4",
+                "@vue/server-renderer": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "node_modules/wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true
+        },
+        "node_modules/yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
         }
-      }
     },
-    "node_modules/@envelop/core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@envelop/core/-/core-4.0.1.tgz",
-      "integrity": "sha512-uBLI7ql3hZopz7vMi9UDAb9HWzKw4STKiqg4QT+lb+tu5ZNaeuJ4fom2rrmgITz38B85QZOhZrGyVrlJXxfDzw==",
-      "dev": true,
-      "dependencies": {
-        "@envelop/types": "4.0.1",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@envelop/types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@envelop/types/-/types-4.0.1.tgz",
-      "integrity": "sha512-ULo27/doEsP7uUhm2iTnElx13qTO6I5FKvmLoX41cpfuw8x6e0NUFknoqhEsLzAbgz8xVS5mjwcxGCXh4lDYzg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@graphql-tools/executor": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.0.tgz",
-      "integrity": "sha512-SKlIcMA71Dha5JnEWlw4XxcaJ+YupuXg0QCZgl2TOLFz4SkGCwU/geAsJvUJFwK2RbVLpQv/UMq67lOaBuwDtg==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "@graphql-typed-document-node/core": "3.2.0",
-        "@repeaterjs/repeater": "^3.0.4",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/merge": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
-      "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/schema": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
-      "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/merge": "^9.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-tools/utils": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.6.tgz",
-      "integrity": "sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "dset": "^3.1.2",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-      "dev": true,
-      "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@graphql-yoga/logger": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/logger/-/logger-1.0.0.tgz",
-      "integrity": "sha512-JYoxwnPggH2BfO+dWlWZkDeFhyFZqaTRGLvFhy+Pjp2UxitEW6nDrw+pEDw/K9tJwMjIFMmTT9VfTqrnESmBHg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.5.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@graphql-yoga/plugin-defer-stream": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/plugin-defer-stream/-/plugin-defer-stream-2.0.4.tgz",
-      "integrity": "sha512-VW59oqldg/9lZOEJrS/D4JQL3M5ARZD3TqUXrGKMAJdmvraZpQ11I+A3ZKLvnznT5Wcoqne6NemEjsD/eB0DKA==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-tools/utils": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.2.0 || ^16.0.0",
-        "graphql-yoga": "^4.0.4"
-      }
-    },
-    "node_modules/@graphql-yoga/subscription": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-4.0.0.tgz",
-      "integrity": "sha512-0qsN/BPPZNMoC2CZ8i+P6PgiJyHh1H35aKDt37qARBDaIOKDQuvEOq7+4txUKElcmXi7DYFo109FkhSQoEajrg==",
-      "dev": true,
-      "dependencies": {
-        "@graphql-yoga/typed-event-target": "^2.0.0",
-        "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/events": "^0.1.0",
-        "tslib": "^2.5.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@graphql-yoga/typed-event-target": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/typed-event-target/-/typed-event-target-2.0.0.tgz",
-      "integrity": "sha512-oA/VGxGmaSDym1glOHrltw43qZsFwLLjBwvh57B79UKX/vo3+UQcRgOyE44c5RP7DCYjkrC2tuArZmb6jCzysw==",
-      "dev": true,
-      "dependencies": {
-        "@repeaterjs/repeater": "^3.0.4",
-        "tslib": "^2.5.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@repeaterjs/repeater": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
-      "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
-    },
-    "node_modules/@types/node": {
-      "version": "18.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/@types/web-bluetooth": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
-      "integrity": "sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==",
-      "dev": true
-    },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "node_modules/@vue/devtools-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==",
-      "dev": true
-    },
-    "node_modules/@vue/reactivity": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "node_modules/@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
-      }
-    },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
-      "dev": true,
-      "dependencies": {
-        "@vue/reactivity": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "node_modules/@vue/runtime-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/runtime-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "csstype": "^3.1.1"
-      }
-    },
-    "node_modules/@vue/server-renderer": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/shared": "3.3.4"
-      },
-      "peerDependencies": {
-        "vue": "3.3.4"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
-      "dev": true
-    },
-    "node_modules/@vueuse/core": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.4.1.tgz",
-      "integrity": "sha512-DkHIfMIoSIBjMgRRvdIvxsyboRZQmImofLyOHADqiVbQVilP8VVHDhBX2ZqoItOgu7dWa8oXiNnScOdPLhdEXg==",
-      "dev": true,
-      "dependencies": {
-        "@types/web-bluetooth": "^0.0.17",
-        "@vueuse/metadata": "10.4.1",
-        "@vueuse/shared": "10.4.1",
-        "vue-demi": ">=0.14.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
-      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vueuse/integrations": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.4.1.tgz",
-      "integrity": "sha512-uRBPyG5Lxoh1A/J+boiioPT3ELEAPEo4t8W6Mr4yTKIQBeW/FcbsotZNPr4k9uz+3QEksMmflWloS9wCnypM7g==",
-      "dev": true,
-      "dependencies": {
-        "@vueuse/core": "10.4.1",
-        "@vueuse/shared": "10.4.1",
-        "vue-demi": ">=0.14.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "async-validator": "*",
-        "axios": "*",
-        "change-case": "*",
-        "drauu": "*",
-        "focus-trap": "*",
-        "fuse.js": "*",
-        "idb-keyval": "*",
-        "jwt-decode": "*",
-        "nprogress": "*",
-        "qrcode": "*",
-        "sortablejs": "*",
-        "universal-cookie": "*"
-      },
-      "peerDependenciesMeta": {
-        "async-validator": {
-          "optional": true
+    "dependencies": {
+        "@algolia/autocomplete-core": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+            "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+            "dev": true,
+            "requires": {
+                "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+                "@algolia/autocomplete-shared": "1.9.3"
+            }
         },
-        "axios": {
-          "optional": true
+        "@algolia/autocomplete-plugin-algolia-insights": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+            "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+            "dev": true,
+            "requires": {
+                "@algolia/autocomplete-shared": "1.9.3"
+            }
         },
-        "change-case": {
-          "optional": true
+        "@algolia/autocomplete-preset-algolia": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+            "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+            "dev": true,
+            "requires": {
+                "@algolia/autocomplete-shared": "1.9.3"
+            }
         },
-        "drauu": {
-          "optional": true
+        "@algolia/autocomplete-shared": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+            "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+            "dev": true,
+            "requires": {}
+        },
+        "@algolia/cache-browser-local-storage": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz",
+            "integrity": "sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==",
+            "dev": true,
+            "requires": {
+                "@algolia/cache-common": "4.20.0"
+            }
+        },
+        "@algolia/cache-common": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.20.0.tgz",
+            "integrity": "sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==",
+            "dev": true
+        },
+        "@algolia/cache-in-memory": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz",
+            "integrity": "sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==",
+            "dev": true,
+            "requires": {
+                "@algolia/cache-common": "4.20.0"
+            }
+        },
+        "@algolia/client-account": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.20.0.tgz",
+            "integrity": "sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==",
+            "dev": true,
+            "requires": {
+                "@algolia/client-common": "4.20.0",
+                "@algolia/client-search": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "@algolia/client-analytics": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.20.0.tgz",
+            "integrity": "sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==",
+            "dev": true,
+            "requires": {
+                "@algolia/client-common": "4.20.0",
+                "@algolia/client-search": "4.20.0",
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "@algolia/client-common": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.20.0.tgz",
+            "integrity": "sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==",
+            "dev": true,
+            "requires": {
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "@algolia/client-personalization": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.20.0.tgz",
+            "integrity": "sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==",
+            "dev": true,
+            "requires": {
+                "@algolia/client-common": "4.20.0",
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "@algolia/client-search": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.20.0.tgz",
+            "integrity": "sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==",
+            "dev": true,
+            "requires": {
+                "@algolia/client-common": "4.20.0",
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "@algolia/logger-common": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.20.0.tgz",
+            "integrity": "sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==",
+            "dev": true
+        },
+        "@algolia/logger-console": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.20.0.tgz",
+            "integrity": "sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==",
+            "dev": true,
+            "requires": {
+                "@algolia/logger-common": "4.20.0"
+            }
+        },
+        "@algolia/requester-browser-xhr": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz",
+            "integrity": "sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==",
+            "dev": true,
+            "requires": {
+                "@algolia/requester-common": "4.20.0"
+            }
+        },
+        "@algolia/requester-common": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.20.0.tgz",
+            "integrity": "sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==",
+            "dev": true
+        },
+        "@algolia/requester-node-http": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz",
+            "integrity": "sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==",
+            "dev": true,
+            "requires": {
+                "@algolia/requester-common": "4.20.0"
+            }
+        },
+        "@algolia/transporter": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.20.0.tgz",
+            "integrity": "sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==",
+            "dev": true,
+            "requires": {
+                "@algolia/cache-common": "4.20.0",
+                "@algolia/logger-common": "4.20.0",
+                "@algolia/requester-common": "4.20.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.22.16",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
+            "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+            "dev": true
+        },
+        "@cspotcode/source-map-support": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "0.3.9"
+            }
+        },
+        "@docsearch/css": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+            "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
+            "dev": true
+        },
+        "@docsearch/js": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.2.tgz",
+            "integrity": "sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==",
+            "dev": true,
+            "requires": {
+                "@docsearch/react": "3.5.2",
+                "preact": "^10.0.0"
+            }
+        },
+        "@docsearch/react": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+            "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
+            "dev": true,
+            "requires": {
+                "@algolia/autocomplete-core": "1.9.3",
+                "@algolia/autocomplete-preset-algolia": "1.9.3",
+                "@docsearch/css": "3.5.2",
+                "algoliasearch": "^4.19.1"
+            }
+        },
+        "@envelop/core": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@envelop/core/-/core-4.0.1.tgz",
+            "integrity": "sha512-uBLI7ql3hZopz7vMi9UDAb9HWzKw4STKiqg4QT+lb+tu5ZNaeuJ4fom2rrmgITz38B85QZOhZrGyVrlJXxfDzw==",
+            "dev": true,
+            "requires": {
+                "@envelop/types": "4.0.1",
+                "tslib": "^2.5.0"
+            }
+        },
+        "@envelop/types": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@envelop/types/-/types-4.0.1.tgz",
+            "integrity": "sha512-ULo27/doEsP7uUhm2iTnElx13qTO6I5FKvmLoX41cpfuw8x6e0NUFknoqhEsLzAbgz8xVS5mjwcxGCXh4lDYzg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.5.0"
+            }
+        },
+        "@esbuild/android-arm": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ia32": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-s390x": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/sunos-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-arm64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-ia32": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-x64": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@graphql-tools/executor": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.0.tgz",
+            "integrity": "sha512-SKlIcMA71Dha5JnEWlw4XxcaJ+YupuXg0QCZgl2TOLFz4SkGCwU/geAsJvUJFwK2RbVLpQv/UMq67lOaBuwDtg==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-typed-document-node/core": "3.2.0",
+                "@repeaterjs/repeater": "^3.0.4",
+                "tslib": "^2.4.0",
+                "value-or-promise": "^1.0.12"
+            }
+        },
+        "@graphql-tools/merge": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
+            "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^10.0.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "@graphql-tools/schema": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
+            "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/merge": "^9.0.0",
+                "@graphql-tools/utils": "^10.0.0",
+                "tslib": "^2.4.0",
+                "value-or-promise": "^1.0.12"
+            }
+        },
+        "@graphql-tools/utils": {
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.6.tgz",
+            "integrity": "sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==",
+            "dev": true,
+            "requires": {
+                "@graphql-typed-document-node/core": "^3.1.1",
+                "dset": "^3.1.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "@graphql-typed-document-node/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+            "dev": true,
+            "requires": {}
+        },
+        "@graphql-yoga/logger": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/logger/-/logger-1.0.0.tgz",
+            "integrity": "sha512-JYoxwnPggH2BfO+dWlWZkDeFhyFZqaTRGLvFhy+Pjp2UxitEW6nDrw+pEDw/K9tJwMjIFMmTT9VfTqrnESmBHg==",
+            "dev": true,
+            "requires": {
+                "tslib": "^2.5.2"
+            }
+        },
+        "@graphql-yoga/plugin-defer-stream": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/plugin-defer-stream/-/plugin-defer-stream-2.0.4.tgz",
+            "integrity": "sha512-VW59oqldg/9lZOEJrS/D4JQL3M5ARZD3TqUXrGKMAJdmvraZpQ11I+A3ZKLvnznT5Wcoqne6NemEjsD/eB0DKA==",
+            "dev": true,
+            "requires": {
+                "@graphql-tools/utils": "^10.0.0"
+            }
+        },
+        "@graphql-yoga/subscription": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-4.0.0.tgz",
+            "integrity": "sha512-0qsN/BPPZNMoC2CZ8i+P6PgiJyHh1H35aKDt37qARBDaIOKDQuvEOq7+4txUKElcmXi7DYFo109FkhSQoEajrg==",
+            "dev": true,
+            "requires": {
+                "@graphql-yoga/typed-event-target": "^2.0.0",
+                "@repeaterjs/repeater": "^3.0.4",
+                "@whatwg-node/events": "^0.1.0",
+                "tslib": "^2.5.2"
+            }
+        },
+        "@graphql-yoga/typed-event-target": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@graphql-yoga/typed-event-target/-/typed-event-target-2.0.0.tgz",
+            "integrity": "sha512-oA/VGxGmaSDym1glOHrltw43qZsFwLLjBwvh57B79UKX/vo3+UQcRgOyE44c5RP7DCYjkrC2tuArZmb6jCzysw==",
+            "dev": true,
+            "requires": {
+                "@repeaterjs/repeater": "^3.0.4",
+                "tslib": "^2.5.2"
+            }
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "dev": true
+        },
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+            "dev": true
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.9",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "@repeaterjs/repeater": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
+            "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
+            "dev": true
+        },
+        "@tsconfig/node10": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+            "dev": true
+        },
+        "@tsconfig/node12": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+            "dev": true
+        },
+        "@tsconfig/node14": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+            "dev": true
+        },
+        "@tsconfig/node16": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+            "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "18.14.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
+            "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
+            "dev": true,
+            "peer": true
+        },
+        "@types/web-bluetooth": {
+            "version": "0.0.17",
+            "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
+            "integrity": "sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==",
+            "dev": true
+        },
+        "@vue/compiler-core": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
+            "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.21.3",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "@vue/compiler-dom": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
+            "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "@vue/compiler-sfc": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
+            "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.20.15",
+                "@vue/compiler-core": "3.3.4",
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/compiler-ssr": "3.3.4",
+                "@vue/reactivity-transform": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.0",
+                "postcss": "^8.1.10",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "@vue/compiler-ssr": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
+            "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "@vue/devtools-api": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
+            "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==",
+            "dev": true
+        },
+        "@vue/reactivity": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
+            "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+            "dev": true,
+            "requires": {
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "@vue/reactivity-transform": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
+            "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.20.15",
+                "@vue/compiler-core": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.0"
+            }
+        },
+        "@vue/runtime-core": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
+            "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+            "dev": true,
+            "requires": {
+                "@vue/reactivity": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "@vue/runtime-dom": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
+            "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+            "dev": true,
+            "requires": {
+                "@vue/runtime-core": "3.3.4",
+                "@vue/shared": "3.3.4",
+                "csstype": "^3.1.1"
+            }
+        },
+        "@vue/server-renderer": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
+            "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-ssr": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "@vue/shared": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
+            "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+            "dev": true
+        },
+        "@vueuse/core": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.4.1.tgz",
+            "integrity": "sha512-DkHIfMIoSIBjMgRRvdIvxsyboRZQmImofLyOHADqiVbQVilP8VVHDhBX2ZqoItOgu7dWa8oXiNnScOdPLhdEXg==",
+            "dev": true,
+            "requires": {
+                "@types/web-bluetooth": "^0.0.17",
+                "@vueuse/metadata": "10.4.1",
+                "@vueuse/shared": "10.4.1",
+                "vue-demi": ">=0.14.5"
+            },
+            "dependencies": {
+                "vue-demi": {
+                    "version": "0.14.6",
+                    "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+                    "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+                    "dev": true,
+                    "requires": {}
+                }
+            }
+        },
+        "@vueuse/integrations": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.4.1.tgz",
+            "integrity": "sha512-uRBPyG5Lxoh1A/J+boiioPT3ELEAPEo4t8W6Mr4yTKIQBeW/FcbsotZNPr4k9uz+3QEksMmflWloS9wCnypM7g==",
+            "dev": true,
+            "requires": {
+                "@vueuse/core": "10.4.1",
+                "@vueuse/shared": "10.4.1",
+                "vue-demi": ">=0.14.5"
+            },
+            "dependencies": {
+                "vue-demi": {
+                    "version": "0.14.6",
+                    "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+                    "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+                    "dev": true,
+                    "requires": {}
+                }
+            }
+        },
+        "@vueuse/metadata": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.4.1.tgz",
+            "integrity": "sha512-2Sc8X+iVzeuMGHr6O2j4gv/zxvQGGOYETYXEc41h0iZXIRnRbJZGmY/QP8dvzqUelf8vg0p/yEA5VpCEu+WpZg==",
+            "dev": true
+        },
+        "@vueuse/shared": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.4.1.tgz",
+            "integrity": "sha512-vz5hbAM4qA0lDKmcr2y3pPdU+2EVw/yzfRsBdu+6+USGa4PxqSQRYIUC9/NcT06y+ZgaTsyURw2I9qOFaaXHAg==",
+            "dev": true,
+            "requires": {
+                "vue-demi": ">=0.14.5"
+            },
+            "dependencies": {
+                "vue-demi": {
+                    "version": "0.14.6",
+                    "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+                    "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+                    "dev": true,
+                    "requires": {}
+                }
+            }
+        },
+        "@whatwg-node/events": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+            "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+            "dev": true
+        },
+        "@whatwg-node/fetch": {
+            "version": "0.9.13",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.13.tgz",
+            "integrity": "sha512-PPtMwhjtS96XROnSpowCQM85gCUG2m7AXZFw0PZlGbhzx2GK7f2iOXilfgIJ0uSlCuuGbOIzfouISkA7C4FJOw==",
+            "dev": true,
+            "requires": {
+                "@whatwg-node/node-fetch": "^0.4.17",
+                "urlpattern-polyfill": "^9.0.0"
+            }
+        },
+        "@whatwg-node/node-fetch": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.19.tgz",
+            "integrity": "sha512-AW7/m2AuweAoSXmESrYQr/KBafueScNbn2iNO0u6xFr2JZdPmYsSm5yvAXYk6yDLv+eDmSSKrf7JnFZ0CsJIdA==",
+            "dev": true,
+            "requires": {
+                "@whatwg-node/events": "^0.1.0",
+                "busboy": "^1.6.0",
+                "fast-querystring": "^1.1.1",
+                "fast-url-parser": "^1.1.3",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@whatwg-node/server": {
+            "version": "0.9.14",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.14.tgz",
+            "integrity": "sha512-I8TT0NoCP+xThLBuGlU6dgq5wpExkphNMo2geZwQW0vAmEPtc3MNMZMIYqg5GyNmpv5Nf7fnxb8tVOIHbDvuDA==",
+            "dev": true,
+            "requires": {
+                "@whatwg-node/fetch": "^0.9.10",
+                "tslib": "^2.3.1"
+            }
+        },
+        "acorn": {
+            "version": "8.8.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+            "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+            "dev": true
+        },
+        "acorn-walk": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "dev": true
+        },
+        "algoliasearch": {
+            "version": "4.20.0",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.20.0.tgz",
+            "integrity": "sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==",
+            "dev": true,
+            "requires": {
+                "@algolia/cache-browser-local-storage": "4.20.0",
+                "@algolia/cache-common": "4.20.0",
+                "@algolia/cache-in-memory": "4.20.0",
+                "@algolia/client-account": "4.20.0",
+                "@algolia/client-analytics": "4.20.0",
+                "@algolia/client-common": "4.20.0",
+                "@algolia/client-personalization": "4.20.0",
+                "@algolia/client-search": "4.20.0",
+                "@algolia/logger-common": "4.20.0",
+                "@algolia/logger-console": "4.20.0",
+                "@algolia/requester-browser-xhr": "4.20.0",
+                "@algolia/requester-common": "4.20.0",
+                "@algolia/requester-node-http": "4.20.0",
+                "@algolia/transporter": "4.20.0"
+            }
+        },
+        "ansi-sequence-parser": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+            "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+            "dev": true
+        },
+        "arg": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "busboy": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+            "dev": true,
+            "requires": {
+                "streamsearch": "^1.1.0"
+            }
+        },
+        "create-require": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+            "dev": true
+        },
+        "csstype": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+            "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+            "dev": true
+        },
+        "diff": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "dev": true
+        },
+        "dset": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+            "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+            "dev": true
+        },
+        "esbuild": {
+            "version": "0.18.20",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "dev": true,
+            "requires": {
+                "@esbuild/android-arm": "0.18.20",
+                "@esbuild/android-arm64": "0.18.20",
+                "@esbuild/android-x64": "0.18.20",
+                "@esbuild/darwin-arm64": "0.18.20",
+                "@esbuild/darwin-x64": "0.18.20",
+                "@esbuild/freebsd-arm64": "0.18.20",
+                "@esbuild/freebsd-x64": "0.18.20",
+                "@esbuild/linux-arm": "0.18.20",
+                "@esbuild/linux-arm64": "0.18.20",
+                "@esbuild/linux-ia32": "0.18.20",
+                "@esbuild/linux-loong64": "0.18.20",
+                "@esbuild/linux-mips64el": "0.18.20",
+                "@esbuild/linux-ppc64": "0.18.20",
+                "@esbuild/linux-riscv64": "0.18.20",
+                "@esbuild/linux-s390x": "0.18.20",
+                "@esbuild/linux-x64": "0.18.20",
+                "@esbuild/netbsd-x64": "0.18.20",
+                "@esbuild/openbsd-x64": "0.18.20",
+                "@esbuild/sunos-x64": "0.18.20",
+                "@esbuild/win32-arm64": "0.18.20",
+                "@esbuild/win32-ia32": "0.18.20",
+                "@esbuild/win32-x64": "0.18.20"
+            }
+        },
+        "estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
+        "fast-decode-uri-component": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+            "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+            "dev": true
+        },
+        "fast-querystring": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+            "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+            "dev": true,
+            "requires": {
+                "fast-decode-uri-component": "^1.0.1"
+            }
+        },
+        "fast-url-parser": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+            "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^1.3.2"
+            }
         },
         "focus-trap": {
-          "optional": true
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+            "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+            "dev": true,
+            "requires": {
+                "tabbable": "^6.2.0"
+            }
         },
-        "fuse.js": {
-          "optional": true
+        "fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "optional": true
         },
-        "idb-keyval": {
-          "optional": true
+        "graphql": {
+            "version": "16.6.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+            "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
         },
-        "jwt-decode": {
-          "optional": true
+        "graphql-compose": {
+            "version": "9.0.10",
+            "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-9.0.10.tgz",
+            "integrity": "sha512-UsVoxfi2+c8WbHl2pEB+teoRRZoY4mbWBoijeLDGpAZBSPChnqtSRjp+T9UcouLCwGr5ooNyOQLoI3OVzU1bPQ==",
+            "requires": {
+                "graphql-type-json": "0.3.2"
+            }
         },
-        "nprogress": {
-          "optional": true
+        "graphql-type-json": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
+            "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
+            "requires": {}
         },
-        "qrcode": {
-          "optional": true
+        "graphql-yoga": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-4.0.4.tgz",
+            "integrity": "sha512-MvCLhFecYNIKuxAZisPjpIL9lxRYbpgPSNKENDO/8CV3oiFlsLJHZb5dp2sVAeLafXHeZ9TgkijLthUBc1+Jag==",
+            "dev": true,
+            "requires": {
+                "@envelop/core": "^4.0.0",
+                "@graphql-tools/executor": "^1.0.0",
+                "@graphql-tools/schema": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-yoga/logger": "^1.0.0",
+                "@graphql-yoga/subscription": "^4.0.0",
+                "@whatwg-node/fetch": "^0.9.7",
+                "@whatwg-node/server": "^0.9.1",
+                "dset": "^3.1.1",
+                "lru-cache": "^10.0.0",
+                "tslib": "^2.5.2"
+            }
         },
-        "sortablejs": {
-          "optional": true
+        "handlebars": {
+            "version": "4.7.7",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+            "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
+            }
         },
-        "universal-cookie": {
-          "optional": true
+        "jsonc-parser": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
+            "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+            "dev": true
+        },
+        "lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
+        "magic-string": {
+            "version": "0.30.3",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
+            "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/sourcemap-codec": "^1.4.15"
+            }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
+        "mark.js": {
+            "version": "8.11.1",
+            "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+            "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+            "dev": true
+        },
+        "marked": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
+            "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^2.0.1"
+            }
+        },
+        "minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true
+        },
+        "minisearch": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.1.0.tgz",
+            "integrity": "sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg==",
+            "dev": true
+        },
+        "nanoid": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
+        },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
+        },
+        "postcss": {
+            "version": "8.4.30",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
+            "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+            "dev": true,
+            "requires": {
+                "nanoid": "^3.3.6",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+            }
+        },
+        "preact": {
+            "version": "10.17.1",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
+            "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
+            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+            "dev": true
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+            "dev": true
+        },
+        "rollup": {
+            "version": "3.29.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.2.tgz",
+            "integrity": "sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==",
+            "dev": true,
+            "requires": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "safe-stable-stringify": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+            "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
+        },
+        "search-insights": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.2.tgz",
+            "integrity": "sha512-PxA9M5Q2bpBelVvJ3oDZR8nuY00Z6qwOxL53wNpgzV28M/D6u9WUbImDckjLSILBF8F1hn/mgyuUaOPtjow4Qw==",
+            "dev": true,
+            "peer": true
+        },
+        "shiki": {
+            "version": "0.14.4",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
+            "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
+            "dev": true,
+            "requires": {
+                "ansi-sequence-parser": "^1.1.0",
+                "jsonc-parser": "^3.2.0",
+                "vscode-oniguruma": "^1.7.0",
+                "vscode-textmate": "^8.0.0"
+            }
+        },
+        "single-user-cache": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/single-user-cache/-/single-user-cache-0.6.0.tgz",
+            "integrity": "sha512-uMrANoiybpbsrVDbZ2M7GPzxeqZiirwkVnsDAre1zGhXAAw+2dImTxu7h0l1sIVtwGeJnVsRxgG4I5rZrUX0rw==",
+            "requires": {
+                "safe-stable-stringify": "^2.0.0"
+            }
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true
+        },
+        "source-map-js": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "dev": true
+        },
+        "streamsearch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+            "dev": true
+        },
+        "tabbable": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+            "dev": true
+        },
+        "ts-node": {
+            "version": "10.9.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+            "dev": true,
+            "requires": {
+                "@cspotcode/source-map-support": "^0.8.0",
+                "@tsconfig/node10": "^1.0.7",
+                "@tsconfig/node12": "^1.0.7",
+                "@tsconfig/node14": "^1.0.0",
+                "@tsconfig/node16": "^1.0.2",
+                "acorn": "^8.4.1",
+                "acorn-walk": "^8.1.1",
+                "arg": "^4.1.0",
+                "create-require": "^1.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "v8-compile-cache-lib": "^3.0.1",
+                "yn": "3.1.1"
+            }
+        },
+        "tslib": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "dev": true
+        },
+        "typedoc": {
+            "version": "0.23.28",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
+            "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
+            "dev": true,
+            "requires": {
+                "lunr": "^2.3.9",
+                "marked": "^4.2.12",
+                "minimatch": "^7.1.3",
+                "shiki": "^0.14.1"
+            }
+        },
+        "typedoc-plugin-markdown": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
+            "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
+            "dev": true,
+            "requires": {
+                "handlebars": "^4.7.7"
+            }
+        },
+        "typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.17.4",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "dev": true,
+            "optional": true
+        },
+        "urlpattern-polyfill": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "dev": true
+        },
+        "v8-compile-cache-lib": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+            "dev": true
+        },
+        "value-or-promise": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
+            "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+            "dev": true
+        },
+        "vite": {
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+            "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+            "dev": true,
+            "requires": {
+                "esbuild": "^0.18.10",
+                "fsevents": "~2.3.2",
+                "postcss": "^8.4.27",
+                "rollup": "^3.27.1"
+            }
+        },
+        "vitepress": {
+            "version": "1.0.0-rc.15",
+            "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.15.tgz",
+            "integrity": "sha512-5criiHoEibkT/du7t6wQ2xQVsuTNuirQZbMAi0M9Hp0YzJoJvEX68Ej9p2PtNC84bYb/CxAh5QkMtMutk03lHw==",
+            "dev": true,
+            "requires": {
+                "@docsearch/css": "^3.5.2",
+                "@docsearch/js": "^3.5.2",
+                "@vue/devtools-api": "^6.5.0",
+                "@vueuse/core": "^10.4.1",
+                "@vueuse/integrations": "^10.4.1",
+                "focus-trap": "^7.5.2",
+                "mark.js": "8.11.1",
+                "minisearch": "^6.1.0",
+                "shiki": "^0.14.4",
+                "vite": "^4.4.9",
+                "vue": "^3.3.4"
+            }
+        },
+        "vscode-oniguruma": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+            "dev": true
+        },
+        "vscode-textmate": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+            "dev": true
+        },
+        "vue": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
+            "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-dom": "3.3.4",
+                "@vue/compiler-sfc": "3.3.4",
+                "@vue/runtime-dom": "3.3.4",
+                "@vue/server-renderer": "3.3.4",
+                "@vue/shared": "3.3.4"
+            }
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+            "dev": true
         }
-      }
-    },
-    "node_modules/@vueuse/integrations/node_modules/vue-demi": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
-      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vueuse/metadata": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.4.1.tgz",
-      "integrity": "sha512-2Sc8X+iVzeuMGHr6O2j4gv/zxvQGGOYETYXEc41h0iZXIRnRbJZGmY/QP8dvzqUelf8vg0p/yEA5VpCEu+WpZg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/shared": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.4.1.tgz",
-      "integrity": "sha512-vz5hbAM4qA0lDKmcr2y3pPdU+2EVw/yzfRsBdu+6+USGa4PxqSQRYIUC9/NcT06y+ZgaTsyURw2I9qOFaaXHAg==",
-      "dev": true,
-      "dependencies": {
-        "vue-demi": ">=0.14.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
-      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@whatwg-node/events": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
-      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
-      "dev": true,
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@whatwg-node/fetch": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.13.tgz",
-      "integrity": "sha512-PPtMwhjtS96XROnSpowCQM85gCUG2m7AXZFw0PZlGbhzx2GK7f2iOXilfgIJ0uSlCuuGbOIzfouISkA7C4FJOw==",
-      "dev": true,
-      "dependencies": {
-        "@whatwg-node/node-fetch": "^0.4.17",
-        "urlpattern-polyfill": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.19.tgz",
-      "integrity": "sha512-AW7/m2AuweAoSXmESrYQr/KBafueScNbn2iNO0u6xFr2JZdPmYsSm5yvAXYk6yDLv+eDmSSKrf7JnFZ0CsJIdA==",
-      "dev": true,
-      "dependencies": {
-        "@whatwg-node/events": "^0.1.0",
-        "busboy": "^1.6.0",
-        "fast-querystring": "^1.1.1",
-        "fast-url-parser": "^1.1.3",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@whatwg-node/server": {
-      "version": "0.9.14",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.14.tgz",
-      "integrity": "sha512-I8TT0NoCP+xThLBuGlU6dgq5wpExkphNMo2geZwQW0vAmEPtc3MNMZMIYqg5GyNmpv5Nf7fnxb8tVOIHbDvuDA==",
-      "dev": true,
-      "dependencies": {
-        "@whatwg-node/fetch": "^0.9.10",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/algoliasearch": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.20.0.tgz",
-      "integrity": "sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==",
-      "dev": true,
-      "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.20.0",
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/cache-in-memory": "4.20.0",
-        "@algolia/client-account": "4.20.0",
-        "@algolia/client-analytics": "4.20.0",
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-personalization": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/logger-console": "4.20.0",
-        "@algolia/requester-browser-xhr": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/requester-node-http": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "node_modules/ansi-sequence-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
-      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
-      "dev": true
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
-    "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dset": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
-      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
-    },
-    "node_modules/fast-decode-uri-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
-    },
-    "node_modules/fast-querystring": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
-      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "dev": true,
-      "dependencies": {
-        "fast-decode-uri-component": "^1.0.1"
-      }
-    },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
-    "node_modules/focus-trap": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
-      "dev": true,
-      "dependencies": {
-        "tabbable": "^6.2.0"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
-      "engines": {
-        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-      }
-    },
-    "node_modules/graphql-compose": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-9.0.10.tgz",
-      "integrity": "sha512-UsVoxfi2+c8WbHl2pEB+teoRRZoY4mbWBoijeLDGpAZBSPChnqtSRjp+T9UcouLCwGr5ooNyOQLoI3OVzU1bPQ==",
-      "dependencies": {
-        "graphql-type-json": "0.3.2"
-      }
-    },
-    "node_modules/graphql-type-json": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
-      "peerDependencies": {
-        "graphql": ">=0.8.0"
-      }
-    },
-    "node_modules/graphql-yoga": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-4.0.4.tgz",
-      "integrity": "sha512-MvCLhFecYNIKuxAZisPjpIL9lxRYbpgPSNKENDO/8CV3oiFlsLJHZb5dp2sVAeLafXHeZ9TgkijLthUBc1+Jag==",
-      "dev": true,
-      "dependencies": {
-        "@envelop/core": "^4.0.0",
-        "@graphql-tools/executor": "^1.0.0",
-        "@graphql-tools/schema": "^10.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "@graphql-yoga/logger": "^1.0.0",
-        "@graphql-yoga/subscription": "^4.0.0",
-        "@whatwg-node/fetch": "^0.9.7",
-        "@whatwg-node/server": "^0.9.1",
-        "dset": "^3.1.1",
-        "lru-cache": "^10.0.0",
-        "tslib": "^2.5.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.2.0 || ^16.0.0"
-      }
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
-    },
-    "node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
-    "node_modules/mark.js": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
-      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
-      "dev": true
-    },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-      "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minisearch": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.1.0.tgz",
-      "integrity": "sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg==",
-      "dev": true
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
-    },
-    "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
-    },
-    "node_modules/postcss": {
-      "version": "8.4.30",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-      "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/preact": {
-      "version": "10.17.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
-      "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
-    },
-    "node_modules/rollup": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.2.tgz",
-      "integrity": "sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==",
-      "dev": true,
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/safe-stable-stringify": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/search-insights": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.2.tgz",
-      "integrity": "sha512-PxA9M5Q2bpBelVvJ3oDZR8nuY00Z6qwOxL53wNpgzV28M/D6u9WUbImDckjLSILBF8F1hn/mgyuUaOPtjow4Qw==",
-      "dev": true,
-      "peer": true
-    },
-    "node_modules/shiki": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
-      "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
-      }
-    },
-    "node_modules/single-user-cache": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/single-user-cache/-/single-user-cache-0.6.0.tgz",
-      "integrity": "sha512-uMrANoiybpbsrVDbZ2M7GPzxeqZiirwkVnsDAre1zGhXAAw+2dImTxu7h0l1sIVtwGeJnVsRxgG4I5rZrUX0rw==",
-      "dependencies": {
-        "safe-stable-stringify": "^2.0.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
-    "node_modules/typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
-      "dev": true,
-      "dependencies": {
-        "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
-        "shiki": "^0.14.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 14.14"
-      },
-      "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
-      }
-    },
-    "node_modules/typedoc-plugin-markdown": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
-      "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
-      "dev": true,
-      "dependencies": {
-        "handlebars": "^4.7.7"
-      },
-      "peerDependencies": {
-        "typedoc": ">=0.23.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/urlpattern-polyfill": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
-      "dev": true
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
-    },
-    "node_modules/value-or-promise": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
-      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
-      "dev": true,
-      "dependencies": {
-        "esbuild": "^0.18.10",
-        "postcss": "^8.4.27",
-        "rollup": "^3.27.1"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
-      "peerDependencies": {
-        "@types/node": ">= 14",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitepress": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.15.tgz",
-      "integrity": "sha512-5criiHoEibkT/du7t6wQ2xQVsuTNuirQZbMAi0M9Hp0YzJoJvEX68Ej9p2PtNC84bYb/CxAh5QkMtMutk03lHw==",
-      "dev": true,
-      "dependencies": {
-        "@docsearch/css": "^3.5.2",
-        "@docsearch/js": "^3.5.2",
-        "@vue/devtools-api": "^6.5.0",
-        "@vueuse/core": "^10.4.1",
-        "@vueuse/integrations": "^10.4.1",
-        "focus-trap": "^7.5.2",
-        "mark.js": "8.11.1",
-        "minisearch": "^6.1.0",
-        "shiki": "^0.14.4",
-        "vite": "^4.4.9",
-        "vue": "^3.3.4"
-      },
-      "bin": {
-        "vitepress": "bin/vitepress.js"
-      },
-      "peerDependencies": {
-        "markdown-it-mathjax3": "^4.3.2"
-      },
-      "peerDependenciesMeta": {
-        "markdown-it-mathjax3": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
-    },
-    "node_modules/vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "dev": true
-    },
-    "node_modules/vue": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
-      "dev": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-sfc": "3.3.4",
-        "@vue/runtime-dom": "3.3.4",
-        "@vue/server-renderer": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
     }
-  },
-  "dependencies": {
-    "@algolia/autocomplete-core": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
-      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
-      "dev": true,
-      "requires": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
-        "@algolia/autocomplete-shared": "1.9.3"
-      }
-    },
-    "@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
-      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
-      "dev": true,
-      "requires": {
-        "@algolia/autocomplete-shared": "1.9.3"
-      }
-    },
-    "@algolia/autocomplete-preset-algolia": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
-      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
-      "dev": true,
-      "requires": {
-        "@algolia/autocomplete-shared": "1.9.3"
-      }
-    },
-    "@algolia/autocomplete-shared": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
-      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "@algolia/cache-browser-local-storage": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz",
-      "integrity": "sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.20.0"
-      }
-    },
-    "@algolia/cache-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.20.0.tgz",
-      "integrity": "sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==",
-      "dev": true
-    },
-    "@algolia/cache-in-memory": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz",
-      "integrity": "sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.20.0"
-      }
-    },
-    "@algolia/client-account": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.20.0.tgz",
-      "integrity": "sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "@algolia/client-analytics": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.20.0.tgz",
-      "integrity": "sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "@algolia/client-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.20.0.tgz",
-      "integrity": "sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "@algolia/client-personalization": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.20.0.tgz",
-      "integrity": "sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "@algolia/client-search": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.20.0.tgz",
-      "integrity": "sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==",
-      "dev": true,
-      "requires": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "@algolia/logger-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.20.0.tgz",
-      "integrity": "sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==",
-      "dev": true
-    },
-    "@algolia/logger-console": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.20.0.tgz",
-      "integrity": "sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==",
-      "dev": true,
-      "requires": {
-        "@algolia/logger-common": "4.20.0"
-      }
-    },
-    "@algolia/requester-browser-xhr": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz",
-      "integrity": "sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.20.0"
-      }
-    },
-    "@algolia/requester-common": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.20.0.tgz",
-      "integrity": "sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==",
-      "dev": true
-    },
-    "@algolia/requester-node-http": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz",
-      "integrity": "sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==",
-      "dev": true,
-      "requires": {
-        "@algolia/requester-common": "4.20.0"
-      }
-    },
-    "@algolia/transporter": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.20.0.tgz",
-      "integrity": "sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0"
-      }
-    },
-    "@babel/parser": {
-      "version": "7.22.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
-      "dev": true
-    },
-    "@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      }
-    },
-    "@docsearch/css": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
-      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
-      "dev": true
-    },
-    "@docsearch/js": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.2.tgz",
-      "integrity": "sha512-p1YFTCDflk8ieHgFJYfmyHBki1D61+U9idwrLh+GQQMrBSP3DLGKpy0XUJtPjAOPltcVbqsTjiPFfH7JImjUNg==",
-      "dev": true,
-      "requires": {
-        "@docsearch/react": "3.5.2",
-        "preact": "^10.0.0"
-      }
-    },
-    "@docsearch/react": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
-      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
-      "dev": true,
-      "requires": {
-        "@algolia/autocomplete-core": "1.9.3",
-        "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.5.2",
-        "algoliasearch": "^4.19.1"
-      }
-    },
-    "@envelop/core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@envelop/core/-/core-4.0.1.tgz",
-      "integrity": "sha512-uBLI7ql3hZopz7vMi9UDAb9HWzKw4STKiqg4QT+lb+tu5ZNaeuJ4fom2rrmgITz38B85QZOhZrGyVrlJXxfDzw==",
-      "dev": true,
-      "requires": {
-        "@envelop/types": "4.0.1",
-        "tslib": "^2.5.0"
-      }
-    },
-    "@envelop/types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@envelop/types/-/types-4.0.1.tgz",
-      "integrity": "sha512-ULo27/doEsP7uUhm2iTnElx13qTO6I5FKvmLoX41cpfuw8x6e0NUFknoqhEsLzAbgz8xVS5mjwcxGCXh4lDYzg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.0"
-      }
-    },
-    "@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/darwin-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@graphql-tools/executor": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.0.tgz",
-      "integrity": "sha512-SKlIcMA71Dha5JnEWlw4XxcaJ+YupuXg0QCZgl2TOLFz4SkGCwU/geAsJvUJFwK2RbVLpQv/UMq67lOaBuwDtg==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "^10.0.0",
-        "@graphql-typed-document-node/core": "3.2.0",
-        "@repeaterjs/repeater": "^3.0.4",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      }
-    },
-    "@graphql-tools/merge": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
-      "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "^10.0.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "@graphql-tools/schema": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
-      "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/merge": "^9.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "tslib": "^2.4.0",
-        "value-or-promise": "^1.0.12"
-      }
-    },
-    "@graphql-tools/utils": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.6.tgz",
-      "integrity": "sha512-hZMjl/BbX10iagovakgf3IiqArx8TPsotq5pwBld37uIX1JiZoSbgbCIFol7u55bh32o6cfDEiiJgfAD5fbeyQ==",
-      "dev": true,
-      "requires": {
-        "@graphql-typed-document-node/core": "^3.1.1",
-        "dset": "^3.1.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "@graphql-typed-document-node/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "@graphql-yoga/logger": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/logger/-/logger-1.0.0.tgz",
-      "integrity": "sha512-JYoxwnPggH2BfO+dWlWZkDeFhyFZqaTRGLvFhy+Pjp2UxitEW6nDrw+pEDw/K9tJwMjIFMmTT9VfTqrnESmBHg==",
-      "dev": true,
-      "requires": {
-        "tslib": "^2.5.2"
-      }
-    },
-    "@graphql-yoga/plugin-defer-stream": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/plugin-defer-stream/-/plugin-defer-stream-2.0.4.tgz",
-      "integrity": "sha512-VW59oqldg/9lZOEJrS/D4JQL3M5ARZD3TqUXrGKMAJdmvraZpQ11I+A3ZKLvnznT5Wcoqne6NemEjsD/eB0DKA==",
-      "dev": true,
-      "requires": {
-        "@graphql-tools/utils": "^10.0.0"
-      }
-    },
-    "@graphql-yoga/subscription": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/subscription/-/subscription-4.0.0.tgz",
-      "integrity": "sha512-0qsN/BPPZNMoC2CZ8i+P6PgiJyHh1H35aKDt37qARBDaIOKDQuvEOq7+4txUKElcmXi7DYFo109FkhSQoEajrg==",
-      "dev": true,
-      "requires": {
-        "@graphql-yoga/typed-event-target": "^2.0.0",
-        "@repeaterjs/repeater": "^3.0.4",
-        "@whatwg-node/events": "^0.1.0",
-        "tslib": "^2.5.2"
-      }
-    },
-    "@graphql-yoga/typed-event-target": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@graphql-yoga/typed-event-target/-/typed-event-target-2.0.0.tgz",
-      "integrity": "sha512-oA/VGxGmaSDym1glOHrltw43qZsFwLLjBwvh57B79UKX/vo3+UQcRgOyE44c5RP7DCYjkrC2tuArZmb6jCzysw==",
-      "dev": true,
-      "requires": {
-        "@repeaterjs/repeater": "^3.0.4",
-        "tslib": "^2.5.2"
-      }
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@repeaterjs/repeater": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
-      "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
-      "dev": true
-    },
-    "@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "18.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
-      "dev": true,
-      "peer": true
-    },
-    "@types/web-bluetooth": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
-      "integrity": "sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==",
-      "dev": true
-    },
-    "@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
-      "dev": true,
-      "requires": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
-      "dev": true,
-      "requires": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "@vue/devtools-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
-      "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==",
-      "dev": true
-    },
-    "@vue/reactivity": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
-      "dev": true,
-      "requires": {
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-      "dev": true,
-      "requires": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
-      }
-    },
-    "@vue/runtime-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
-      "dev": true,
-      "requires": {
-        "@vue/reactivity": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "@vue/runtime-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
-      "dev": true,
-      "requires": {
-        "@vue/runtime-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "csstype": "^3.1.1"
-      }
-    },
-    "@vue/server-renderer": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
-      "dev": true,
-      "requires": {
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
-      "dev": true
-    },
-    "@vueuse/core": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.4.1.tgz",
-      "integrity": "sha512-DkHIfMIoSIBjMgRRvdIvxsyboRZQmImofLyOHADqiVbQVilP8VVHDhBX2ZqoItOgu7dWa8oXiNnScOdPLhdEXg==",
-      "dev": true,
-      "requires": {
-        "@types/web-bluetooth": "^0.0.17",
-        "@vueuse/metadata": "10.4.1",
-        "@vueuse/shared": "10.4.1",
-        "vue-demi": ">=0.14.5"
-      },
-      "dependencies": {
-        "vue-demi": {
-          "version": "0.14.6",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
-          "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
-    "@vueuse/integrations": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.4.1.tgz",
-      "integrity": "sha512-uRBPyG5Lxoh1A/J+boiioPT3ELEAPEo4t8W6Mr4yTKIQBeW/FcbsotZNPr4k9uz+3QEksMmflWloS9wCnypM7g==",
-      "dev": true,
-      "requires": {
-        "@vueuse/core": "10.4.1",
-        "@vueuse/shared": "10.4.1",
-        "vue-demi": ">=0.14.5"
-      },
-      "dependencies": {
-        "vue-demi": {
-          "version": "0.14.6",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
-          "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
-    "@vueuse/metadata": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.4.1.tgz",
-      "integrity": "sha512-2Sc8X+iVzeuMGHr6O2j4gv/zxvQGGOYETYXEc41h0iZXIRnRbJZGmY/QP8dvzqUelf8vg0p/yEA5VpCEu+WpZg==",
-      "dev": true
-    },
-    "@vueuse/shared": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.4.1.tgz",
-      "integrity": "sha512-vz5hbAM4qA0lDKmcr2y3pPdU+2EVw/yzfRsBdu+6+USGa4PxqSQRYIUC9/NcT06y+ZgaTsyURw2I9qOFaaXHAg==",
-      "dev": true,
-      "requires": {
-        "vue-demi": ">=0.14.5"
-      },
-      "dependencies": {
-        "vue-demi": {
-          "version": "0.14.6",
-          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
-          "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
-          "dev": true,
-          "requires": {}
-        }
-      }
-    },
-    "@whatwg-node/events": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
-      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
-      "dev": true
-    },
-    "@whatwg-node/fetch": {
-      "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.13.tgz",
-      "integrity": "sha512-PPtMwhjtS96XROnSpowCQM85gCUG2m7AXZFw0PZlGbhzx2GK7f2iOXilfgIJ0uSlCuuGbOIzfouISkA7C4FJOw==",
-      "dev": true,
-      "requires": {
-        "@whatwg-node/node-fetch": "^0.4.17",
-        "urlpattern-polyfill": "^9.0.0"
-      }
-    },
-    "@whatwg-node/node-fetch": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.19.tgz",
-      "integrity": "sha512-AW7/m2AuweAoSXmESrYQr/KBafueScNbn2iNO0u6xFr2JZdPmYsSm5yvAXYk6yDLv+eDmSSKrf7JnFZ0CsJIdA==",
-      "dev": true,
-      "requires": {
-        "@whatwg-node/events": "^0.1.0",
-        "busboy": "^1.6.0",
-        "fast-querystring": "^1.1.1",
-        "fast-url-parser": "^1.1.3",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@whatwg-node/server": {
-      "version": "0.9.14",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.14.tgz",
-      "integrity": "sha512-I8TT0NoCP+xThLBuGlU6dgq5wpExkphNMo2geZwQW0vAmEPtc3MNMZMIYqg5GyNmpv5Nf7fnxb8tVOIHbDvuDA==",
-      "dev": true,
-      "requires": {
-        "@whatwg-node/fetch": "^0.9.10",
-        "tslib": "^2.3.1"
-      }
-    },
-    "acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true
-    },
-    "acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
-    },
-    "algoliasearch": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.20.0.tgz",
-      "integrity": "sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==",
-      "dev": true,
-      "requires": {
-        "@algolia/cache-browser-local-storage": "4.20.0",
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/cache-in-memory": "4.20.0",
-        "@algolia/client-account": "4.20.0",
-        "@algolia/client-analytics": "4.20.0",
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-personalization": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/logger-console": "4.20.0",
-        "@algolia/requester-browser-xhr": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/requester-node-http": "4.20.0",
-        "@algolia/transporter": "4.20.0"
-      }
-    },
-    "ansi-sequence-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
-      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
-      "dev": true
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
-      "requires": {
-        "streamsearch": "^1.1.0"
-      }
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
-    "csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
-    },
-    "dset": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
-      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
-      "dev": true
-    },
-    "esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "dev": true,
-      "requires": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
-    },
-    "fast-decode-uri-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
-    },
-    "fast-querystring": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
-      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "dev": true,
-      "requires": {
-        "fast-decode-uri-component": "^1.0.1"
-      }
-    },
-    "fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "requires": {
-        "punycode": "^1.3.2"
-      }
-    },
-    "focus-trap": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
-      "dev": true,
-      "requires": {
-        "tabbable": "^6.2.0"
-      }
-    },
-    "fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "optional": true
-    },
-    "graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
-    },
-    "graphql-compose": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-9.0.10.tgz",
-      "integrity": "sha512-UsVoxfi2+c8WbHl2pEB+teoRRZoY4mbWBoijeLDGpAZBSPChnqtSRjp+T9UcouLCwGr5ooNyOQLoI3OVzU1bPQ==",
-      "requires": {
-        "graphql-type-json": "0.3.2"
-      }
-    },
-    "graphql-type-json": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
-      "requires": {}
-    },
-    "graphql-yoga": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/graphql-yoga/-/graphql-yoga-4.0.4.tgz",
-      "integrity": "sha512-MvCLhFecYNIKuxAZisPjpIL9lxRYbpgPSNKENDO/8CV3oiFlsLJHZb5dp2sVAeLafXHeZ9TgkijLthUBc1+Jag==",
-      "dev": true,
-      "requires": {
-        "@envelop/core": "^4.0.0",
-        "@graphql-tools/executor": "^1.0.0",
-        "@graphql-tools/schema": "^10.0.0",
-        "@graphql-tools/utils": "^10.0.0",
-        "@graphql-yoga/logger": "^1.0.0",
-        "@graphql-yoga/subscription": "^4.0.0",
-        "@whatwg-node/fetch": "^0.9.7",
-        "@whatwg-node/server": "^0.9.1",
-        "dset": "^3.1.1",
-        "lru-cache": "^10.0.0",
-        "tslib": "^2.5.2"
-      }
-    },
-    "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
-    },
-    "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
-      "dev": true
-    },
-    "lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
-    },
-    "magic-string": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
-      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
-      }
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
-    "mark.js": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
-      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
-      "dev": true
-    },
-    "marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.3.tgz",
-      "integrity": "sha512-5UB4yYusDtkRPbRiy1cqZ1IpGNcJCGlEMG17RKzPddpyiPKoCdwohbED8g4QXT0ewCt8LTkQXuljsUfQ3FKM4A==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^2.0.1"
-      }
-    },
-    "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true
-    },
-    "minisearch": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.1.0.tgz",
-      "integrity": "sha512-PNxA/X8pWk+TiqPbsoIYH0GQ5Di7m6326/lwU/S4mlo4wGQddIcf/V//1f9TB0V4j59b57b+HZxt8h3iMROGvg==",
-      "dev": true
-    },
-    "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
-    },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
-    },
-    "postcss": {
-      "version": "8.4.30",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-      "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "preact": {
-      "version": "10.17.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.17.1.tgz",
-      "integrity": "sha512-X9BODrvQ4Ekwv9GURm9AKAGaomqXmip7NQTZgY7gcNmr7XE83adOMJvd3N42id1tMFU7ojiynRsYnY6/BRFxLA==",
-      "dev": true
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
-    },
-    "rollup": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.2.tgz",
-      "integrity": "sha512-CJouHoZ27v6siztc21eEQGo0kIcE5D1gVPA571ez0mMYb25LGYGKnVNXpEj5MGlepmDWGXNjDB5q7uNiPHC11A==",
-      "dev": true,
-      "requires": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "safe-stable-stringify": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
-      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
-    },
-    "search-insights": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.2.tgz",
-      "integrity": "sha512-PxA9M5Q2bpBelVvJ3oDZR8nuY00Z6qwOxL53wNpgzV28M/D6u9WUbImDckjLSILBF8F1hn/mgyuUaOPtjow4Qw==",
-      "dev": true,
-      "peer": true
-    },
-    "shiki": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.4.tgz",
-      "integrity": "sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==",
-      "dev": true,
-      "requires": {
-        "ansi-sequence-parser": "^1.1.0",
-        "jsonc-parser": "^3.2.0",
-        "vscode-oniguruma": "^1.7.0",
-        "vscode-textmate": "^8.0.0"
-      }
-    },
-    "single-user-cache": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/single-user-cache/-/single-user-cache-0.6.0.tgz",
-      "integrity": "sha512-uMrANoiybpbsrVDbZ2M7GPzxeqZiirwkVnsDAre1zGhXAAw+2dImTxu7h0l1sIVtwGeJnVsRxgG4I5rZrUX0rw==",
-      "requires": {
-        "safe-stable-stringify": "^2.0.0"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
-    },
-    "streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true
-    },
-    "tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true
-    },
-    "ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "requires": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      }
-    },
-    "tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
-    "typedoc": {
-      "version": "0.23.28",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.28.tgz",
-      "integrity": "sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==",
-      "dev": true,
-      "requires": {
-        "lunr": "^2.3.9",
-        "marked": "^4.2.12",
-        "minimatch": "^7.1.3",
-        "shiki": "^0.14.1"
-      }
-    },
-    "typedoc-plugin-markdown": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
-      "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
-      "dev": true,
-      "requires": {
-        "handlebars": "^4.7.7"
-      }
-    },
-    "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true
-    },
-    "uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "optional": true
-    },
-    "urlpattern-polyfill": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
-      "dev": true
-    },
-    "v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
-    },
-    "value-or-promise": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
-      "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
-      "dev": true
-    },
-    "vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
-      "dev": true,
-      "requires": {
-        "esbuild": "^0.18.10",
-        "fsevents": "~2.3.2",
-        "postcss": "^8.4.27",
-        "rollup": "^3.27.1"
-      }
-    },
-    "vitepress": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.15.tgz",
-      "integrity": "sha512-5criiHoEibkT/du7t6wQ2xQVsuTNuirQZbMAi0M9Hp0YzJoJvEX68Ej9p2PtNC84bYb/CxAh5QkMtMutk03lHw==",
-      "dev": true,
-      "requires": {
-        "@docsearch/css": "^3.5.2",
-        "@docsearch/js": "^3.5.2",
-        "@vue/devtools-api": "^6.5.0",
-        "@vueuse/core": "^10.4.1",
-        "@vueuse/integrations": "^10.4.1",
-        "focus-trap": "^7.5.2",
-        "mark.js": "8.11.1",
-        "minisearch": "^6.1.0",
-        "shiki": "^0.14.4",
-        "vite": "^4.4.9",
-        "vue": "^3.3.4"
-      }
-    },
-    "vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
-    },
-    "vscode-textmate": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "dev": true
-    },
-    "vue": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
-      "dev": true,
-      "requires": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-sfc": "3.3.4",
-        "@vue/runtime-dom": "3.3.4",
-        "@vue/server-renderer": "3.3.4",
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
-    }
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,33 +1,35 @@
 {
-  "name": "garph",
-  "description": "A tRPC-like schema-builder for GraphQL",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/stepci/garph"
-  },
-  "version": "0.6.4",
-  "license": "MIT",
-  "main": "dist/index.js",
-  "scripts": {
-    "docs:dev": "vitepress dev",
-    "docs:build": "vitepress build",
-    "docs:preview": "vitepress preview",
-    "build": "tsc -p tsconfig.json",
-    "postbuild": "typedoc --readme none --entryDocument index.md --plugin typedoc-plugin-markdown --tsconfig tsconfig.json --hideInPageTOC true --out www/api src/index.ts",
-    "test": "ts-node examples/relay.ts"
-  },
-  "devDependencies": {
-    "@graphql-yoga/plugin-defer-stream": "^2.0.4",
-    "graphql": "^16.6.0",
-    "graphql-yoga": "^4.0.4",
-    "ts-node": "^10.9.1",
-    "typedoc": "^0.23.27",
-    "typedoc-plugin-markdown": "^3.14.0",
-    "typescript": "^4.9.5",
-    "vitepress": "^1.0.0-rc.15"
-  },
-  "dependencies": {
-    "graphql-compose": "^9.0.10",
-    "single-user-cache": "^0.6.0"
-  }
+    "name": "garph",
+    "description": "A tRPC-like schema-builder for GraphQL",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/stepci/garph"
+    },
+    "version": "0.6.4",
+    "license": "MIT",
+    "main": "dist/index.js",
+    "scripts": {
+        "docs:dev": "vitepress dev",
+        "docs:build": "vitepress build",
+        "docs:preview": "vitepress preview",
+        "build": "tsc -p tsconfig.json",
+        "format": "prettier -w .",
+        "postbuild": "typedoc --readme none --entryDocument index.md --plugin typedoc-plugin-markdown --tsconfig tsconfig.json --hideInPageTOC true --out www/api src/index.ts",
+        "test": "ts-node examples/relay.ts"
+    },
+    "devDependencies": {
+        "@graphql-yoga/plugin-defer-stream": "^2.0.4",
+        "graphql": "^16.6.0",
+        "graphql-yoga": "^4.0.4",
+        "ts-node": "^10.9.1",
+        "typedoc": "^0.23.27",
+        "typedoc-plugin-markdown": "^3.14.0",
+        "typescript": "^4.9.5",
+        "vitepress": "^1.0.0-rc.15",
+        "prettier": "^3.1.1"
+    },
+    "dependencies": {
+        "graphql-compose": "^9.0.10",
+        "single-user-cache": "^0.6.0"
+    }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,42 +1,84 @@
-import { InferArg, AnyInput, AnyInterface, AnyString, AnyID, AnyBoolean, AnyNumber, AnyList, AnyPaginatedList, AnyOptional, AnyArgs, AnyUnion, AnyEnum, AnyScalar, AnyRef, AnyObject, AnyOmitResolver } from './index'
+import {
+    InferArg,
+    AnyInput,
+    AnyInterface,
+    AnyString,
+    AnyID,
+    AnyBoolean,
+    AnyNumber,
+    AnyList,
+    AnyPaginatedList,
+    AnyOptional,
+    AnyArgs,
+    AnyUnion,
+    AnyEnum,
+    AnyScalar,
+    AnyRef,
+    AnyObject,
+    AnyOmitResolver,
+} from './index'
 import { ExpandRecursively } from './utils'
 
 export type ClientTypes = {
-  query: AnyObject
-  mutation?: AnyObject
-  subscription?: AnyObject
+    query: AnyObject
+    mutation?: AnyObject
+    subscription?: AnyObject
 }
 
 export type InferClient<T extends ClientTypes> = {
-  [K in keyof T]: InferClientTypes<T[K]>
+    [K in keyof T]: InferClientTypes<T[K]>
 }
 
 export type InferClientTypes<T> = ExpandRecursively<InferClientTypesRaw<T>>
-export type InferClientTypesRaw<T> = T extends AnyInput | AnyObject | AnyInterface ? {
-  __typename: T['_name']
-} & {
-  [K in keyof T['_shape'] as T['_shape'][K] extends AnyOptional ? never : K]: InferClientTypesRaw<T['_shape'][K]>
-} & {
-  [K in keyof T['_shape'] as T['_shape'][K] extends AnyOptional ? K : never]?: InferClientTypesRaw<T['_shape'][K]>
-}: InferClientTypesShallow<T>
-
-export type InferClientTypesShallow<T> =
-  T extends AnyString | AnyID | AnyNumber | AnyBoolean ? T['_shape'] :
-  T extends AnyScalar ? T['_output'] :
-  T extends AnyEnum ? T['_inner'] :
-  T extends AnyUnion ? {
-    $on: {
-      __typename: keyof {
-        [K in keyof T['_inner'] as T['_inner'][K]['_name']]: never
+export type InferClientTypesRaw<T> = T extends
+    | AnyInput
+    | AnyObject
+    | AnyInterface
+    ? {
+          __typename: T['_name']
+      } & {
+          [K in keyof T['_shape'] as T['_shape'][K] extends AnyOptional
+              ? never
+              : K]: InferClientTypesRaw<T['_shape'][K]>
+      } & {
+          [K in keyof T['_shape'] as T['_shape'][K] extends AnyOptional
+              ? K
+              : never]?: InferClientTypesRaw<T['_shape'][K]>
       }
-    } & {
-      [K in keyof T['_inner'] as T['_inner'][K]['_name']]?: InferClientTypesRaw<T['_inner'][K]>
-    }
-  } :
-  T extends AnyList ? InferClientTypesRaw<T['_shape']>[] :
-  T extends AnyPaginatedList ? T['_inner'] :
-  T extends AnyOptional ? InferClientTypesRaw<T['_shape']> | null | undefined :
-  T extends AnyOmitResolver ? InferClientTypesRaw<T['_shape']> :
-  T extends AnyArgs ? (args?: InferArg<T>) => InferClientTypes<T['_shape']> :
-  T extends AnyRef ? InferClientTypesRaw<T['_inner']> :
-  T
+    : InferClientTypesShallow<T>
+
+export type InferClientTypesShallow<T> = T extends
+    | AnyString
+    | AnyID
+    | AnyNumber
+    | AnyBoolean
+    ? T['_shape']
+    : T extends AnyScalar
+      ? T['_output']
+      : T extends AnyEnum
+        ? T['_inner']
+        : T extends AnyUnion
+          ? {
+                $on: {
+                    __typename: keyof {
+                        [K in keyof T['_inner'] as T['_inner'][K]['_name']]: never
+                    }
+                } & {
+                    [K in keyof T['_inner'] as T['_inner'][K]['_name']]?: InferClientTypesRaw<
+                        T['_inner'][K]
+                    >
+                }
+            }
+          : T extends AnyList
+            ? InferClientTypesRaw<T['_shape']>[]
+            : T extends AnyPaginatedList
+              ? T['_inner']
+              : T extends AnyOptional
+                ? InferClientTypesRaw<T['_shape']> | null | undefined
+                : T extends AnyOmitResolver
+                  ? InferClientTypesRaw<T['_shape']>
+                  : T extends AnyArgs
+                    ? (args?: InferArg<T>) => InferClientTypes<T['_shape']>
+                    : T extends AnyRef
+                      ? InferClientTypesRaw<T['_inner']>
+                      : T

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,43 +1,68 @@
 import type { GraphQLResolveInfo } from 'graphql'
-import { TSEnumType, UnionToIntersection, getEnumProperties, ObjectToUnion, ExpandRecursively, MaybePromise, MaybeFunction } from './utils'
+import {
+    TSEnumType,
+    UnionToIntersection,
+    getEnumProperties,
+    ObjectToUnion,
+    ExpandRecursively,
+    MaybePromise,
+    MaybeFunction,
+} from './utils'
 import { buildSchema, printSchema } from './schema'
 
 type GraphQLRootType = 'Query' | 'Mutation' | 'Subscription'
-type GarphType = 'String' | 'Int' | 'Float' | 'Boolean' | 'ID' | 'ObjectType' | 'InterfaceType' | 'InputType' | 'Scalar' | 'Enum' | 'List' | 'PaginatedList' | 'Union' | 'Ref' | 'Optional' | 'Args' | 'OmitResolver'
+type GarphType =
+    | 'String'
+    | 'Int'
+    | 'Float'
+    | 'Boolean'
+    | 'ID'
+    | 'ObjectType'
+    | 'InterfaceType'
+    | 'InputType'
+    | 'Scalar'
+    | 'Enum'
+    | 'List'
+    | 'PaginatedList'
+    | 'Union'
+    | 'Ref'
+    | 'Optional'
+    | 'Args'
+    | 'OmitResolver'
 
 export abstract class Type<T, X extends GarphType> {
-  _name?: string
-  _is: X
-  _inner?: any
-  _output?: any
-  _args?: Args
-  _shape: T
-  typeDef: TypeDefinition<T>
+    _name?: string
+    _is: X
+    _inner?: any
+    _output?: any
+    _args?: Args
+    _shape: T
+    typeDef: TypeDefinition<T>
 
-  description(text: string) {
-    this.typeDef.description = text
-    return this
-  }
+    description(text: string) {
+        this.typeDef.description = text
+        return this
+    }
 
-  deprecated(reason: string) {
-    this.typeDef.deprecated = reason
-    return this
-  }
+    deprecated(reason: string) {
+        this.typeDef.deprecated = reason
+        return this
+    }
 }
 
 export type TypeDefinition<T> = {
-  name?: string
-  type: GarphType
-  shape?: T
-  args?: Args
-  description?: string
-  isOptional?: boolean
-  isRequired?: boolean
-  deprecated?: string
-  scalarOptions?: ScalarOptions<any, any>
-  defaultValue?: any
-  interfaces?: AnyInterface[]
-  extend?: AnyTypes[]
+    name?: string
+    type: GarphType
+    shape?: T
+    args?: Args
+    description?: string
+    isOptional?: boolean
+    isRequired?: boolean
+    deprecated?: string
+    scalarOptions?: ScalarOptions<any, any>
+    defaultValue?: any
+    interfaces?: AnyInterface[]
+    extend?: AnyTypes[]
 }
 
 export type AnyType = Type<any, any>
@@ -61,662 +86,969 @@ export type AnyObject = Type<any, 'ObjectType'>
 export type AnyOmitResolver = Type<any, 'OmitResolver'>
 
 export type Args = {
-  [key: string]: AnyType
+    [key: string]: AnyType
 }
 
 export type AnyTypes = {
-  [key: string]: AnyType
+    [key: string]: AnyType
 }
 
 export type AnyObjects = {
-  [key: string]: AnyObject
+    [key: string]: AnyObject
 }
 
 type ScalarOptions<I, O> = {
-  serialize: (value: I) => O
-  parseValue: (value: O) => I
-  parseLiteral?: (ast: any) => I
-  specifiedByUrl?: string
+    serialize: (value: I) => O
+    parseValue: (value: O) => I
+    parseLiteral?: (ast: any) => I
+    specifiedByUrl?: string
 }
 
 type InferResolverConfig = {
-  context?: any
+    context?: any
 }
 
 type InferOptions = {
-  omitResolver?: AnyOmitResolver | never
+    omitResolver?: AnyOmitResolver | never
 }
 
 type RefType = () => AnyType
 
 // TODO: Refactor Args to get rid of this mess
-export type Infer<T, options extends InferOptions = { omitResolver: never }> = ExpandRecursively<InferRaw<T, options>>
-export type InferRaw<T, options extends InferOptions = { omitResolver: never }> = T extends AnyInput | AnyObject | AnyInterface ? {
-  __typename?: T['_name']
-} & {
-  [K in keyof T['_shape'] as T['_shape'][K] extends AnyOptional | options['omitResolver'] ? never :
-  T['_shape'][K] extends AnyArgs ?
-  T['_shape'][K]['_shape'] extends AnyOptional | options['omitResolver'] ? never : K :
-  K]: InferRaw<T['_shape'][K], options>
-} & {
-  [K in keyof T['_shape'] as T['_shape'][K] extends AnyOptional | options['omitResolver'] ? K :
-  T['_shape'][K] extends AnyArgs ?
-  T['_shape'][K]['_shape'] extends AnyOptional | options['omitResolver'] ? K : never :
-  never]?: InferRaw<T['_shape'][K], options>
-} : InferShallow<T, options>
+export type Infer<
+    T,
+    options extends InferOptions = { omitResolver: never },
+> = ExpandRecursively<InferRaw<T, options>>
+export type InferRaw<
+    T,
+    options extends InferOptions = { omitResolver: never },
+> = T extends AnyInput | AnyObject | AnyInterface
+    ? {
+          __typename?: T['_name']
+      } & {
+          [K in keyof T['_shape'] as T['_shape'][K] extends
+              | AnyOptional
+              | options['omitResolver']
+              ? never
+              : T['_shape'][K] extends AnyArgs
+                ? T['_shape'][K]['_shape'] extends
+                      | AnyOptional
+                      | options['omitResolver']
+                    ? never
+                    : K
+                : K]: InferRaw<T['_shape'][K], options>
+      } & {
+          [K in keyof T['_shape'] as T['_shape'][K] extends
+              | AnyOptional
+              | options['omitResolver']
+              ? K
+              : T['_shape'][K] extends AnyArgs
+                ? T['_shape'][K]['_shape'] extends
+                      | AnyOptional
+                      | options['omitResolver']
+                    ? K
+                    : never
+                : never]?: InferRaw<T['_shape'][K], options>
+      }
+    : InferShallow<T, options>
 
-export type InferShallow<T, options extends InferOptions = { omitResolver: never }> =
-  T extends AnyString | AnyID | AnyScalar | AnyNumber | AnyBoolean ? T['_shape'] :
-  T extends AnyEnum ? T['_inner'] :
-  T extends AnyUnion ? InferRaw<ObjectToUnion<T['_inner']>, options> :
-  T extends AnyList ? InferRaw<T['_shape'], options>[] :
-  T extends AnyPaginatedList ? T['_inner'] :
-  T extends AnyOptional ? InferRaw<T['_shape'], options> | null | undefined :
-  T extends AnyOmitResolver ? InferRaw<T['_shape'], options> :
-  T extends AnyArgs ? InferRaw<T['_shape'], options> :
-  T extends AnyRef ? InferRaw<T['_inner'], options> :
-  T
+export type InferShallow<
+    T,
+    options extends InferOptions = { omitResolver: never },
+> = T extends AnyString | AnyID | AnyScalar | AnyNumber | AnyBoolean
+    ? T['_shape']
+    : T extends AnyEnum
+      ? T['_inner']
+      : T extends AnyUnion
+        ? InferRaw<ObjectToUnion<T['_inner']>, options>
+        : T extends AnyList
+          ? InferRaw<T['_shape'], options>[]
+          : T extends AnyPaginatedList
+            ? T['_inner']
+            : T extends AnyOptional
+              ? InferRaw<T['_shape'], options> | null | undefined
+              : T extends AnyOmitResolver
+                ? InferRaw<T['_shape'], options>
+                : T extends AnyArgs
+                  ? InferRaw<T['_shape'], options>
+                  : T extends AnyRef
+                    ? InferRaw<T['_inner'], options>
+                    : T
 
 export type InferArgs<T extends AnyType> = ExpandRecursively<InferArgsRaw<T>>
-export type InferArgsRaw<T extends AnyType> = T extends AnyObject | AnyInterface ? {
-  [K in keyof T['_shape']]: InferArgRaw<T['_shape'][K]>
-} : never
+export type InferArgsRaw<T extends AnyType> = T extends AnyObject | AnyInterface
+    ? {
+          [K in keyof T['_shape']]: InferArgRaw<T['_shape'][K]>
+      }
+    : never
 
 export type InferArg<T> = ExpandRecursively<InferArgRaw<T>>
-export type InferArgRaw<T> = T extends AnyArgs ? {
-  [K in keyof T['_args'] as T['_args'][K] extends AnyOptional ? never : K]: InferRaw<T['_args'][K]>
-} & {
-  [K in keyof T['_args'] as T['_args'][K] extends AnyOptional ? K : never]?: InferRaw<T['_args'][K]>
-}: never
+export type InferArgRaw<T> = T extends AnyArgs
+    ? {
+          [K in keyof T['_args'] as T['_args'][K] extends AnyOptional
+              ? never
+              : K]: InferRaw<T['_args'][K]>
+      } & {
+          [K in keyof T['_args'] as T['_args'][K] extends AnyOptional
+              ? K
+              : never]?: InferRaw<T['_args'][K]>
+      }
+    : never
 
-export type InferUnionNames<T> = T extends AnyUnion ? ObjectToUnion<T['_inner']>['_name'] : never
+export type InferUnionNames<T> = T extends AnyUnion
+    ? ObjectToUnion<T['_inner']>['_name']
+    : never
 
-export type InferResolvers<T extends AnyTypes, X extends InferResolverConfig> = {
-  [K in keyof T]: K extends 'Subscription' ? {
-    [G in keyof T[K]['_shape']]?: {
-      subscribe: (parent: {}, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<AsyncIterator<{ [G in keyof T[K]['_shape']]: Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }> }>>
-      resolve?: (value: Infer<T[K]['_shape'][G]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>>
-    }
-  } : {
-    [G in keyof T[K]['_shape']]?: (parent: K extends GraphQLRootType ? {} : Infer<T[K]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<MaybeFunction<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>>> | AsyncGenerator<Infer<T[K]['_shape'][G]['_shape'], { omitResolver: AnyOmitResolver }>>
-  } | {
-    [G in keyof T[K]['_shape']]?: {
-      resolve: (parent: K extends GraphQLRootType ? {} : Infer<T[K]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>> | AsyncGenerator<Infer<T[K]['_shape'][G]['_shape'], { omitResolver: AnyOmitResolver }>>
-    } | {
-      load: (queries: { parent: K extends GraphQLRootType ? {} : Infer<T[K]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo } []) => MaybePromise<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>>[]
-    } | {
-      loadBatch: (queries: { parent: K extends GraphQLRootType ? {} : Infer<T[K]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo } []) => MaybePromise<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>>[]
-    }
-  } & {
-    __isTypeOf?: (parent: Infer<T[K]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<boolean>
-    __resolveType?: (parent: Infer<T[K]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<InferUnionNames<T[K]>>
-  }
+export type InferResolvers<
+    T extends AnyTypes,
+    X extends InferResolverConfig,
+> = {
+    [K in keyof T]: K extends 'Subscription'
+        ? {
+              [G in keyof T[K]['_shape']]?: {
+                  subscribe: (
+                      parent: {},
+                      args: InferArg<T[K]['_shape'][G]>,
+                      context: X['context'],
+                      info: GraphQLResolveInfo
+                  ) => MaybePromise<
+                      AsyncIterator<{
+                          [G in keyof T[K]['_shape']]: Infer<
+                              T[K]['_shape'][G],
+                              { omitResolver: AnyOmitResolver }
+                          >
+                      }>
+                  >
+                  resolve?: (
+                      value: Infer<T[K]['_shape'][G]>,
+                      args: InferArg<T[K]['_shape'][G]>,
+                      context: X['context'],
+                      info: GraphQLResolveInfo
+                  ) => MaybePromise<
+                      Infer<
+                          T[K]['_shape'][G],
+                          { omitResolver: AnyOmitResolver }
+                      >
+                  >
+              }
+          }
+        :
+              | {
+                    [G in keyof T[K]['_shape']]?: (
+                        parent: K extends GraphQLRootType ? {} : Infer<T[K]>,
+                        args: InferArg<T[K]['_shape'][G]>,
+                        context: X['context'],
+                        info: GraphQLResolveInfo
+                    ) =>
+                        | MaybePromise<
+                              MaybeFunction<
+                                  Infer<
+                                      T[K]['_shape'][G],
+                                      { omitResolver: AnyOmitResolver }
+                                  >
+                              >
+                          >
+                        | AsyncGenerator<
+                              Infer<
+                                  T[K]['_shape'][G]['_shape'],
+                                  { omitResolver: AnyOmitResolver }
+                              >
+                          >
+                }
+              | ({
+                    [G in keyof T[K]['_shape']]?:
+                        | {
+                              resolve: (
+                                  parent: K extends GraphQLRootType
+                                      ? {}
+                                      : Infer<T[K]>,
+                                  args: InferArg<T[K]['_shape'][G]>,
+                                  context: X['context'],
+                                  info: GraphQLResolveInfo
+                              ) =>
+                                  | MaybePromise<
+                                        Infer<
+                                            T[K]['_shape'][G],
+                                            { omitResolver: AnyOmitResolver }
+                                        >
+                                    >
+                                  | AsyncGenerator<
+                                        Infer<
+                                            T[K]['_shape'][G]['_shape'],
+                                            { omitResolver: AnyOmitResolver }
+                                        >
+                                    >
+                          }
+                        | {
+                              load: (
+                                  queries: {
+                                      parent: K extends GraphQLRootType
+                                          ? {}
+                                          : Infer<T[K]>
+                                      args: InferArg<T[K]['_shape'][G]>
+                                      context: X['context']
+                                      info: GraphQLResolveInfo
+                                  }[]
+                              ) => MaybePromise<
+                                  Infer<
+                                      T[K]['_shape'][G],
+                                      { omitResolver: AnyOmitResolver }
+                                  >
+                              >[]
+                          }
+                        | {
+                              loadBatch: (
+                                  queries: {
+                                      parent: K extends GraphQLRootType
+                                          ? {}
+                                          : Infer<T[K]>
+                                      args: InferArg<T[K]['_shape'][G]>
+                                      context: X['context']
+                                      info: GraphQLResolveInfo
+                                  }[]
+                              ) => MaybePromise<
+                                  Infer<
+                                      T[K]['_shape'][G],
+                                      { omitResolver: AnyOmitResolver }
+                                  >
+                              >[]
+                          }
+                } & {
+                    __isTypeOf?: (
+                        parent: Infer<T[K]>,
+                        context: X['context'],
+                        info: GraphQLResolveInfo
+                    ) => MaybePromise<boolean>
+                    __resolveType?: (
+                        parent: Infer<T[K]>,
+                        context: X['context'],
+                        info: GraphQLResolveInfo
+                    ) => MaybePromise<InferUnionNames<T[K]>>
+                })
 }
 
-export type InferResolversStrict<T extends AnyTypes, X extends InferResolverConfig> = {
-  [K in keyof T]: K extends 'Subscription' ? {
-    [G in keyof T[K]['_shape']]: {
-      subscribe: (parent: {}, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<AsyncIterator<{ [G in keyof T[K]['_shape']]: Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }> }>>
-      resolve?: (value: Infer<T[K]['_shape'][G]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>>
-    }
-  } : {
-    [G in keyof T[K]['_shape']]: (parent: K extends GraphQLRootType ? {} : Infer<T[K]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<MaybeFunction<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>>> | AsyncGenerator<Infer<T[K]['_shape'][G]['_shape'], { omitResolver: AnyOmitResolver }>>
-  } | {
-    [G in keyof T[K]['_shape']]: {
-      resolve: (parent: K extends GraphQLRootType ? {} : Infer<T[K]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>> | AsyncGenerator<Infer<T[K]['_shape'][G]['_shape'], { omitResolver: AnyOmitResolver }>>
-    } | {
-      load: (queries: { parent: K extends GraphQLRootType ? {} : Infer<T[K]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo } []) => MaybePromise<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>>[]
-    } | {
-      loadBatch: (queries: { parent: K extends GraphQLRootType ? {} : Infer<T[K]>, args: InferArg<T[K]['_shape'][G]>, context: X['context'], info: GraphQLResolveInfo } []) => MaybePromise<Infer<T[K]['_shape'][G], { omitResolver: AnyOmitResolver }>>[]
-    }
-  } & {
-    __isTypeOf?: (parent: Infer<T[K]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<boolean>
-    __resolveType?: (parent: Infer<T[K]>, context: X['context'], info: GraphQLResolveInfo) => MaybePromise<InferUnionNames<T[K]>>
-  }
+export type InferResolversStrict<
+    T extends AnyTypes,
+    X extends InferResolverConfig,
+> = {
+    [K in keyof T]: K extends 'Subscription'
+        ? {
+              [G in keyof T[K]['_shape']]: {
+                  subscribe: (
+                      parent: {},
+                      args: InferArg<T[K]['_shape'][G]>,
+                      context: X['context'],
+                      info: GraphQLResolveInfo
+                  ) => MaybePromise<
+                      AsyncIterator<{
+                          [G in keyof T[K]['_shape']]: Infer<
+                              T[K]['_shape'][G],
+                              { omitResolver: AnyOmitResolver }
+                          >
+                      }>
+                  >
+                  resolve?: (
+                      value: Infer<T[K]['_shape'][G]>,
+                      args: InferArg<T[K]['_shape'][G]>,
+                      context: X['context'],
+                      info: GraphQLResolveInfo
+                  ) => MaybePromise<
+                      Infer<
+                          T[K]['_shape'][G],
+                          { omitResolver: AnyOmitResolver }
+                      >
+                  >
+              }
+          }
+        :
+              | {
+                    [G in keyof T[K]['_shape']]: (
+                        parent: K extends GraphQLRootType ? {} : Infer<T[K]>,
+                        args: InferArg<T[K]['_shape'][G]>,
+                        context: X['context'],
+                        info: GraphQLResolveInfo
+                    ) =>
+                        | MaybePromise<
+                              MaybeFunction<
+                                  Infer<
+                                      T[K]['_shape'][G],
+                                      { omitResolver: AnyOmitResolver }
+                                  >
+                              >
+                          >
+                        | AsyncGenerator<
+                              Infer<
+                                  T[K]['_shape'][G]['_shape'],
+                                  { omitResolver: AnyOmitResolver }
+                              >
+                          >
+                }
+              | ({
+                    [G in keyof T[K]['_shape']]:
+                        | {
+                              resolve: (
+                                  parent: K extends GraphQLRootType
+                                      ? {}
+                                      : Infer<T[K]>,
+                                  args: InferArg<T[K]['_shape'][G]>,
+                                  context: X['context'],
+                                  info: GraphQLResolveInfo
+                              ) =>
+                                  | MaybePromise<
+                                        Infer<
+                                            T[K]['_shape'][G],
+                                            { omitResolver: AnyOmitResolver }
+                                        >
+                                    >
+                                  | AsyncGenerator<
+                                        Infer<
+                                            T[K]['_shape'][G]['_shape'],
+                                            { omitResolver: AnyOmitResolver }
+                                        >
+                                    >
+                          }
+                        | {
+                              load: (
+                                  queries: {
+                                      parent: K extends GraphQLRootType
+                                          ? {}
+                                          : Infer<T[K]>
+                                      args: InferArg<T[K]['_shape'][G]>
+                                      context: X['context']
+                                      info: GraphQLResolveInfo
+                                  }[]
+                              ) => MaybePromise<
+                                  Infer<
+                                      T[K]['_shape'][G],
+                                      { omitResolver: AnyOmitResolver }
+                                  >
+                              >[]
+                          }
+                        | {
+                              loadBatch: (
+                                  queries: {
+                                      parent: K extends GraphQLRootType
+                                          ? {}
+                                          : Infer<T[K]>
+                                      args: InferArg<T[K]['_shape'][G]>
+                                      context: X['context']
+                                      info: GraphQLResolveInfo
+                                  }[]
+                              ) => MaybePromise<
+                                  Infer<
+                                      T[K]['_shape'][G],
+                                      { omitResolver: AnyOmitResolver }
+                                  >
+                              >[]
+                          }
+                } & {
+                    __isTypeOf?: (
+                        parent: Infer<T[K]>,
+                        context: X['context'],
+                        info: GraphQLResolveInfo
+                    ) => MaybePromise<boolean>
+                    __resolveType?: (
+                        parent: Infer<T[K]>,
+                        context: X['context'],
+                        info: GraphQLResolveInfo
+                    ) => MaybePromise<InferUnionNames<T[K]>>
+                })
 }
 
-class GType<N extends string, T extends AnyTypes> extends Type<T, 'ObjectType'> {
-  declare _name: N
+class GType<N extends string, T extends AnyTypes> extends Type<
+    T,
+    'ObjectType'
+> {
+    declare _name: N
 
-  constructor(name: string, shape: T, interfaces?: AnyInterface[], extend?: AnyTypes[]) {
-    super()
-    this.typeDef = {
-      name,
-      type: 'ObjectType',
-      shape,
-      interfaces,
-      extend
+    constructor(
+        name: string,
+        shape: T,
+        interfaces?: AnyInterface[],
+        extend?: AnyTypes[]
+    ) {
+        super()
+        this.typeDef = {
+            name,
+            type: 'ObjectType',
+            shape,
+            interfaces,
+            extend,
+        }
     }
-  }
 
-  implements<D extends AnyInterface>(ref: D | D[]) {
-    // This is temporary construct, until we figure out how to properly manage to shared schema
-    this.typeDef.interfaces = Array.isArray(ref) ? ref : [ref]
-    return new GType<N, T & UnionToIntersection<D['_shape']>>(this.typeDef.name, this.typeDef.shape as any, Array.isArray(ref) ? ref : [ref], this.typeDef.extend)
-  }
+    implements<D extends AnyInterface>(ref: D | D[]) {
+        // This is temporary construct, until we figure out how to properly manage to shared schema
+        this.typeDef.interfaces = Array.isArray(ref) ? ref : [ref]
+        return new GType<N, T & UnionToIntersection<D['_shape']>>(
+            this.typeDef.name,
+            this.typeDef.shape as any,
+            Array.isArray(ref) ? ref : [ref],
+            this.typeDef.extend
+        )
+    }
 
-  extend<D extends AnyTypes>(ref: D | D[]) {
-    // This is temporary construct, until we figure out how to properly manage to shared schema
-    this.typeDef.extend = Array.isArray(ref) ? ref : [ref]
-    return new GType<N, T & UnionToIntersection<D>>(this.typeDef.name, this.typeDef.shape as any, this.typeDef.interfaces, Array.isArray(ref) ? ref : [ref])
-  }
+    extend<D extends AnyTypes>(ref: D | D[]) {
+        // This is temporary construct, until we figure out how to properly manage to shared schema
+        this.typeDef.extend = Array.isArray(ref) ? ref : [ref]
+        return new GType<N, T & UnionToIntersection<D>>(
+            this.typeDef.name,
+            this.typeDef.shape as any,
+            this.typeDef.interfaces,
+            Array.isArray(ref) ? ref : [ref]
+        )
+    }
 }
 
-class GInput<N extends string, T extends AnyTypes> extends Type<T, 'InputType'> {
-  declare _name: N
+class GInput<N extends string, T extends AnyTypes> extends Type<
+    T,
+    'InputType'
+> {
+    declare _name: N
 
-  constructor(name: string, shape: T, extend?: AnyTypes[]) {
-    super()
-    this.typeDef = {
-      name,
-      type: 'InputType',
-      shape,
-      extend
+    constructor(name: string, shape: T, extend?: AnyTypes[]) {
+        super()
+        this.typeDef = {
+            name,
+            type: 'InputType',
+            shape,
+            extend,
+        }
     }
-  }
 
-  extend<D extends AnyTypes>(ref: D | D[]) {
-    // This is temporary construct, until we figure out how to properly manage to shared schema
-    this.typeDef.extend = Array.isArray(ref) ? ref : [ref]
-    return new GInput<N, T & UnionToIntersection<D>>(this.typeDef.name, this.typeDef.shape as any, Array.isArray(ref) ? ref : [ref])
-  }
+    extend<D extends AnyTypes>(ref: D | D[]) {
+        // This is temporary construct, until we figure out how to properly manage to shared schema
+        this.typeDef.extend = Array.isArray(ref) ? ref : [ref]
+        return new GInput<N, T & UnionToIntersection<D>>(
+            this.typeDef.name,
+            this.typeDef.shape as any,
+            Array.isArray(ref) ? ref : [ref]
+        )
+    }
 }
 
-class GInterface<N extends string, T extends AnyTypes> extends Type<T, 'InterfaceType'> {
-  declare _name: N
+class GInterface<N extends string, T extends AnyTypes> extends Type<
+    T,
+    'InterfaceType'
+> {
+    declare _name: N
 
-  constructor(name: string, shape: T, interfaces?: AnyInterface[], extend?: AnyTypes[]) {
-    super()
-    this.typeDef = {
-      name,
-      type: 'InterfaceType',
-      shape,
-      interfaces,
-      extend
+    constructor(
+        name: string,
+        shape: T,
+        interfaces?: AnyInterface[],
+        extend?: AnyTypes[]
+    ) {
+        super()
+        this.typeDef = {
+            name,
+            type: 'InterfaceType',
+            shape,
+            interfaces,
+            extend,
+        }
     }
-  }
 
-  implements<D extends AnyInterface>(ref: D | D[]) {
-    // This is temporary construct, until we figure out how to properly manage to shared schema
-    this.typeDef.interfaces = Array.isArray(ref) ? ref : [ref]
-    return new GInterface<N ,T & UnionToIntersection<D['_shape']>>(this.typeDef.name, this.typeDef.shape as any, Array.isArray(ref) ? ref : [ref], this.typeDef.extend)
-  }
+    implements<D extends AnyInterface>(ref: D | D[]) {
+        // This is temporary construct, until we figure out how to properly manage to shared schema
+        this.typeDef.interfaces = Array.isArray(ref) ? ref : [ref]
+        return new GInterface<N, T & UnionToIntersection<D['_shape']>>(
+            this.typeDef.name,
+            this.typeDef.shape as any,
+            Array.isArray(ref) ? ref : [ref],
+            this.typeDef.extend
+        )
+    }
 
-  extend<D extends AnyTypes>(ref: D | D[]) {
-    // This is temporary construct, until we figure out how to properly manage to shared schema
-    this.typeDef.extend = Array.isArray(ref) ? ref : [ref]
-    return new GInterface<N, T & UnionToIntersection<D>>(this.typeDef.name, this.typeDef.shape as any, this.typeDef.interfaces, Array.isArray(ref) ? ref : [ref])
-  }
+    extend<D extends AnyTypes>(ref: D | D[]) {
+        // This is temporary construct, until we figure out how to properly manage to shared schema
+        this.typeDef.extend = Array.isArray(ref) ? ref : [ref]
+        return new GInterface<N, T & UnionToIntersection<D>>(
+            this.typeDef.name,
+            this.typeDef.shape as any,
+            this.typeDef.interfaces,
+            Array.isArray(ref) ? ref : [ref]
+        )
+    }
 }
 
 class GString<T extends GarphType> extends Type<string, T> {
-  constructor(type: 'String' | 'ID' = 'String') {
-    super()
-    this.typeDef = {
-      type
+    constructor(type: 'String' | 'ID' = 'String') {
+        super()
+        this.typeDef = {
+            type,
+        }
     }
-  }
 
-  optional() {
-    return new GOptional<this>(this)
-  }
+    optional() {
+        return new GOptional<this>(this)
+    }
 
-  required() {
-    this.typeDef.isRequired = true
-    return this
-  }
+    required() {
+        this.typeDef.isRequired = true
+        return this
+    }
 
-  list() {
-    return new GList<this>(this)
-  }
+    list() {
+        return new GList<this>(this)
+    }
 
-  default(value: string) {
-    this.typeDef.defaultValue = value
-    return this
-  }
+    default(value: string) {
+        this.typeDef.defaultValue = value
+        return this
+    }
 
-  omitResolver () {
-    return new GOmitResolver<this>(this)
-  }
+    omitResolver() {
+        return new GOmitResolver<this>(this)
+    }
 
-  args<X extends Args>(args: X) {
-    return new GArgs<this, X>(this, args)
-  }
+    args<X extends Args>(args: X) {
+        return new GArgs<this, X>(this, args)
+    }
 }
 
 class GNumber<T extends GarphType> extends Type<number, T> {
-  constructor(type: 'Int' | 'Float' = 'Int') {
-    super()
-    this.typeDef = {
-      type
+    constructor(type: 'Int' | 'Float' = 'Int') {
+        super()
+        this.typeDef = {
+            type,
+        }
     }
-  }
 
-  optional() {
-    return new GOptional<this>(this)
-  }
+    optional() {
+        return new GOptional<this>(this)
+    }
 
-  required() {
-    this.typeDef.isRequired = true
-    return this
-  }
+    required() {
+        this.typeDef.isRequired = true
+        return this
+    }
 
-  list() {
-    return new GList<this>(this)
-  }
+    list() {
+        return new GList<this>(this)
+    }
 
-  default(value: number) {
-    this.typeDef.defaultValue = value
-    return this
-  }
+    default(value: number) {
+        this.typeDef.defaultValue = value
+        return this
+    }
 
-  omitResolver () {
-    return new GOmitResolver<this>(this)
-  }
+    omitResolver() {
+        return new GOmitResolver<this>(this)
+    }
 
-  args<X extends Args>(args: X) {
-    return new GArgs<this, X>(this, args)
-  }
+    args<X extends Args>(args: X) {
+        return new GArgs<this, X>(this, args)
+    }
 }
 
 class GBoolean extends Type<boolean, 'Boolean'> {
-  constructor() {
-    super()
-    this.typeDef = {
-      type: 'Boolean'
+    constructor() {
+        super()
+        this.typeDef = {
+            type: 'Boolean',
+        }
     }
-  }
 
-  optional() {
-    return new GOptional<this>(this)
-  }
+    optional() {
+        return new GOptional<this>(this)
+    }
 
-  required() {
-    this.typeDef.isRequired = true
-    return this
-  }
+    required() {
+        this.typeDef.isRequired = true
+        return this
+    }
 
-  list() {
-    return new GList<this>(this)
-  }
+    list() {
+        return new GList<this>(this)
+    }
 
-  default(value: boolean) {
-    this.typeDef.defaultValue = value
-    return this
-  }
+    default(value: boolean) {
+        this.typeDef.defaultValue = value
+        return this
+    }
 
-  omitResolver () {
-    return new GOmitResolver<this>(this)
-  }
+    omitResolver() {
+        return new GOmitResolver<this>(this)
+    }
 
-  args<X extends Args>(args: X) {
-    return new GArgs<this, X>(this, args)
-  }
+    args<X extends Args>(args: X) {
+        return new GArgs<this, X>(this, args)
+    }
 }
 
-class GEnum<N extends string, T extends readonly string[] | TSEnumType> extends Type<readonly string[], 'Enum'> {
-  declare _name: N
-  declare _inner: T extends readonly string[] ? T[number] : keyof T
+class GEnum<
+    N extends string,
+    T extends readonly string[] | TSEnumType,
+> extends Type<readonly string[], 'Enum'> {
+    declare _name: N
+    declare _inner: T extends readonly string[] ? T[number] : keyof T
 
-  constructor(name: string, shape: T) {
-    super()
+    constructor(name: string, shape: T) {
+        super()
 
-    let enumShape: readonly string[]
-    if (Array.isArray(shape)) {
-      enumShape = shape
-    } else {
-      enumShape = getEnumProperties(shape as TSEnumType)
+        let enumShape: readonly string[]
+        if (Array.isArray(shape)) {
+            enumShape = shape
+        } else {
+            enumShape = getEnumProperties(shape as TSEnumType)
+        }
+
+        this.typeDef = {
+            name,
+            type: 'Enum',
+            shape: enumShape,
+        }
     }
-
-    this.typeDef = {
-      name,
-      type: 'Enum',
-      shape: enumShape
-    }
-  }
 }
 
 class GUnion<N extends string, T extends AnyObjects> extends Type<T, 'Union'> {
-  declare _name: N
-  declare _inner: T
+    declare _name: N
+    declare _inner: T
 
-  constructor(name: string, shape: T) {
-    super()
-    this.typeDef = {
-      name,
-      type: 'Union',
-      shape
+    constructor(name: string, shape: T) {
+        super()
+        this.typeDef = {
+            name,
+            type: 'Union',
+            shape,
+        }
     }
-  }
 }
 
 class GRef<T> extends Type<T, 'Ref'> {
-  declare _inner: T extends RefType ? ReturnType<T> : T
+    declare _inner: T extends RefType ? ReturnType<T> : T
 
-  constructor(ref: T) {
-    super()
-    this.typeDef = {
-      shape: ref,
-      type: 'Ref'
+    constructor(ref: T) {
+        super()
+        this.typeDef = {
+            shape: ref,
+            type: 'Ref',
+        }
     }
-  }
 
-  optional() {
-    return new GOptional<this>(this)
-  }
+    optional() {
+        return new GOptional<this>(this)
+    }
 
-  required() {
-    this.typeDef.isRequired = true
-    return this
-  }
+    required() {
+        this.typeDef.isRequired = true
+        return this
+    }
 
-  list() {
-    return new GList<this>(this)
-  }
+    list() {
+        return new GList<this>(this)
+    }
 
-  paginatedList() {
-    return new GPaginatedList<this>(this)
-  }
+    paginatedList() {
+        return new GPaginatedList<this>(this)
+    }
 
-  default(value: InferRaw<this['_inner']>) {
-    this.typeDef.defaultValue = value
-    return this
-  }
+    default(value: InferRaw<this['_inner']>) {
+        this.typeDef.defaultValue = value
+        return this
+    }
 
-  omitResolver () {
-    return new GOmitResolver<this>(this)
-  }
+    omitResolver() {
+        return new GOmitResolver<this>(this)
+    }
 
-  args<X extends Args>(x: X) {
-    return new GArgs<this, X>(this, x)
-  }
+    args<X extends Args>(x: X) {
+        return new GArgs<this, X>(this, x)
+    }
 }
 
 class GScalar<I, O> extends Type<I, 'Scalar'> {
-  declare _output: O
+    declare _output: O
 
-  constructor(name: string, scalarOptions?: ScalarOptions<I, O>) {
-    super()
-    this.typeDef = {
-      name,
-      type: 'Scalar',
-      scalarOptions
+    constructor(name: string, scalarOptions?: ScalarOptions<I, O>) {
+        super()
+        this.typeDef = {
+            name,
+            type: 'Scalar',
+            scalarOptions,
+        }
     }
-  }
 
-  specifiedByUrl(url: string) {
-    this.typeDef.scalarOptions.specifiedByUrl = url
-    return this
-  }
+    specifiedByUrl(url: string) {
+        this.typeDef.scalarOptions.specifiedByUrl = url
+        return this
+    }
 }
 
 class GList<T extends AnyType> extends Type<T, 'List'> {
-  constructor(shape: T) {
-    super()
-    this.typeDef = {
-      type: 'List',
-      shape: shape
+    constructor(shape: T) {
+        super()
+        this.typeDef = {
+            type: 'List',
+            shape: shape,
+        }
     }
-  }
 
-  optional() {
-    return new GOptional<this>(this)
-  }
+    optional() {
+        return new GOptional<this>(this)
+    }
 
-  required() {
-    this.typeDef.isRequired = true
-    return this
-  }
+    required() {
+        this.typeDef.isRequired = true
+        return this
+    }
 
-  default(value: typeof this._inner) {
-    this.typeDef.defaultValue = value
-    return this
-  }
+    default(value: typeof this._inner) {
+        this.typeDef.defaultValue = value
+        return this
+    }
 
-  omitResolver () {
-    return new GOmitResolver<this>(this)
-  }
+    omitResolver() {
+        return new GOmitResolver<this>(this)
+    }
 
-  args<X extends Args>(args: X) {
-    return new GArgs<this, X>(this, args)
-  }
+    args<X extends Args>(args: X) {
+        return new GArgs<this, X>(this, args)
+    }
 
-  list() {
-    return new GList<this>(this)
-  }
+    list() {
+        return new GList<this>(this)
+    }
 }
 
 class GPaginatedList<T extends AnyType> extends Type<T, 'PaginatedList'> {
-  declare _inner: {
-    edges: {
-      node: InferRaw<T>
-      cursor: string
-    }[]
-    pageInfo: {
-      hasNextPage: boolean,
-      hasPreviousPage: boolean,
-      startCursor?: string,
-      endCursor?: string
+    declare _inner: {
+        edges: {
+            node: InferRaw<T>
+            cursor: string
+        }[]
+        pageInfo: {
+            hasNextPage: boolean
+            hasPreviousPage: boolean
+            startCursor?: string
+            endCursor?: string
+        }
     }
-  }
 
-  constructor(shape: T) {
-    super()
-    this.typeDef = {
-      type: 'PaginatedList',
-      shape: shape
+    constructor(shape: T) {
+        super()
+        this.typeDef = {
+            type: 'PaginatedList',
+            shape: shape,
+        }
     }
-  }
 
-  optional() {
-    return new GOptional<this>(this)
-  }
+    optional() {
+        return new GOptional<this>(this)
+    }
 
-  required() {
-    this.typeDef.isRequired = true
-    return this
-  }
+    required() {
+        this.typeDef.isRequired = true
+        return this
+    }
 
-  omitResolver () {
-    return new GOmitResolver<this>(this)
-  }
+    omitResolver() {
+        return new GOmitResolver<this>(this)
+    }
 
-  args<X extends Args>(args: X) {
-    return new GArgs<this, X>(this, args)
-  }
+    args<X extends Args>(args: X) {
+        return new GArgs<this, X>(this, args)
+    }
 
-  // list() {
-  //   return new GList<this>(this)
-  // }
+    // list() {
+    //   return new GList<this>(this)
+    // }
 }
 
 class GOptional<T extends AnyType> extends Type<T, 'Optional'> {
-  constructor(shape: T) {
-    super()
-    this.typeDef = shape.typeDef
-    this.typeDef.isOptional = true
-    this.typeDef.isRequired = false
-  }
+    constructor(shape: T) {
+        super()
+        this.typeDef = shape.typeDef
+        this.typeDef.isOptional = true
+        this.typeDef.isRequired = false
+    }
 
-  list() {
-    return new GList<this>(this)
-  }
+    list() {
+        return new GList<this>(this)
+    }
 
-  default(value: InferRaw<T>) {
-    this.typeDef.defaultValue = value
-    return this
-  }
+    default(value: InferRaw<T>) {
+        this.typeDef.defaultValue = value
+        return this
+    }
 
-  omitResolver () {
-    return new GOmitResolver<this>(this)
-  }
+    omitResolver() {
+        return new GOmitResolver<this>(this)
+    }
 
-  args<X extends Args>(args: X) {
-    return new GArgs<this, X>(this, args)
-  }
+    args<X extends Args>(args: X) {
+        return new GArgs<this, X>(this, args)
+    }
 }
 
 class GOmitResolver<T extends AnyType> extends Type<T, 'OmitResolver'> {
-  constructor(shape: T) {
-    super()
-    this.typeDef = shape.typeDef
-  }
+    constructor(shape: T) {
+        super()
+        this.typeDef = shape.typeDef
+    }
 
-  optional() {
-    return new GOptional<this>(this)
-  }
+    optional() {
+        return new GOptional<this>(this)
+    }
 
-  required() {
-    this.typeDef.isRequired = true
-    return this
-  }
+    required() {
+        this.typeDef.isRequired = true
+        return this
+    }
 
-  default(value: InferRaw<T>) {
-    this.typeDef.defaultValue = value
-    return this
-  }
+    default(value: InferRaw<T>) {
+        this.typeDef.defaultValue = value
+        return this
+    }
 
-  args<X extends Args>(args: X) {
-    return new GArgs<this, X>(this, args)
-  }
+    args<X extends Args>(args: X) {
+        return new GArgs<this, X>(this, args)
+    }
 
-  list() {
-    return new GList<this>(this)
-  }
+    list() {
+        return new GList<this>(this)
+    }
 }
 
 class GArgs<T extends AnyType, X extends Args> extends Type<T, 'Args'> {
-  declare _args: X
+    declare _args: X
 
-  constructor(shape: T, args: X) {
-    super()
-    this.typeDef = shape.typeDef
-    this.typeDef.args = args
-  }
+    constructor(shape: T, args: X) {
+        super()
+        this.typeDef = shape.typeDef
+        this.typeDef.args = args
+    }
 }
 
 export class GarphSchema {
-  types: AnyType[] = []
-  nodeType = this.interface('Node', {
-    id: this.id()
-  })
-
-  pageInfoType = this.type('PageInfo', {
-    hasNextPage: this.boolean(),
-    hasPreviousPage: this.boolean(),
-    startCursor: this.string().optional(),
-    endCursor: this.string().optional()
-  })
-
-  pageInfoArgs = {
-    first: this.int().optional(),
-    last: this.int().optional(),
-    before: this.id().optional(),
-    after: this.id().optional()
-  }
-
-  constructor ({ types }: { types: AnyType[] } = { types: [] }) {
-    this.types.push(...types)
-  }
-
-  type<N extends string, T extends AnyTypes>(name: N, shape: T) {
-    const t = new GType<N, T>(name, shape)
-    this.types.push(t)
-    return t
-  }
-
-  node<N extends string, T extends AnyTypes>(name: N, shape: T) {
-    const t = new GType<N, T>(name, shape).implements(this.nodeType)
-    this.types.push(t)
-    return t
-  }
-
-  connection<N extends string, T extends AnyRef>(name: N, shape: T) {
-    const t = new GType(name, {
-      edges: new GList(shape),
-      pageInfo: this.pageInfoType
+    types: AnyType[] = []
+    nodeType = this.interface('Node', {
+        id: this.id(),
     })
 
-    this.types.push(t)
-    return t
-  }
-
-  edge<N extends string, T extends AnyRef>(name: N, shape: T) {
-    const t = new GType<N, {
-      node: T
-      cursor: AnyString
-    }>(name, {
-      node: shape,
-      cursor: g.string()
+    pageInfoType = this.type('PageInfo', {
+        hasNextPage: this.boolean(),
+        hasPreviousPage: this.boolean(),
+        startCursor: this.string().optional(),
+        endCursor: this.string().optional(),
     })
 
-    this.types.push(t)
-    return t
-  }
+    pageInfoArgs = {
+        first: this.int().optional(),
+        last: this.int().optional(),
+        before: this.id().optional(),
+        after: this.id().optional(),
+    }
 
-  inputType<N extends string, T extends AnyTypes>(name: N, shape: T) {
-    const t = new GInput<N, T>(name, shape)
-    this.types.push(t)
-    return t
-  }
+    constructor({ types }: { types: AnyType[] } = { types: [] }) {
+        this.types.push(...types)
+    }
 
-  enumType<N extends string, T extends readonly string[] | TSEnumType>(name: N, args: T) {
-    const t = new GEnum<N, T>(name, args)
-    this.types.push(t)
-    return t
-  }
+    type<N extends string, T extends AnyTypes>(name: N, shape: T) {
+        const t = new GType<N, T>(name, shape)
+        this.types.push(t)
+        return t
+    }
 
-  unionType<N extends string, T extends AnyObjects>(name: N, args: T) {
-    const t = new GUnion<N, T>(name, args)
-    this.types.push(t)
-    return t
-  }
+    node<N extends string, T extends AnyTypes>(name: N, shape: T) {
+        const t = new GType<N, T>(name, shape).implements(this.nodeType)
+        this.types.push(t)
+        return t
+    }
 
-  scalarType<I, O>(name: string, options?: ScalarOptions<I, O>) {
-    const t = new GScalar<I, O>(name, options)
-    this.types.push(t)
-    return t
-  }
+    connection<N extends string, T extends AnyRef>(name: N, shape: T) {
+        const t = new GType(name, {
+            edges: new GList(shape),
+            pageInfo: this.pageInfoType,
+        })
 
-  interface<N extends string, T extends AnyTypes>(name: N, shape: T) {
-    const t = new GInterface<N, T>(name, shape)
-    this.types.push(t)
-    return t
-  }
+        this.types.push(t)
+        return t
+    }
 
-  string() {
-    return new GString<'String'>()
-  }
+    edge<N extends string, T extends AnyRef>(name: N, shape: T) {
+        const t = new GType<
+            N,
+            {
+                node: T
+                cursor: AnyString
+            }
+        >(name, {
+            node: shape,
+            cursor: g.string(),
+        })
 
-  id() {
-    return new GString<'ID'>('ID')
-  }
+        this.types.push(t)
+        return t
+    }
 
-  int() {
-    return new GNumber<'Int'>('Int')
-  }
+    inputType<N extends string, T extends AnyTypes>(name: N, shape: T) {
+        const t = new GInput<N, T>(name, shape)
+        this.types.push(t)
+        return t
+    }
 
-  float() {
-    return new GNumber<'Float'>('Float')
-  }
+    enumType<N extends string, T extends readonly string[] | TSEnumType>(
+        name: N,
+        args: T
+    ) {
+        const t = new GEnum<N, T>(name, args)
+        this.types.push(t)
+        return t
+    }
 
-  boolean() {
-    return new GBoolean()
-  }
+    unionType<N extends string, T extends AnyObjects>(name: N, args: T) {
+        const t = new GUnion<N, T>(name, args)
+        this.types.push(t)
+        return t
+    }
 
-  // The generic has to be any, because constraints cannot be applied to recursive types
-  // This is a limitation of TypeScript
-  ref<T>(ref: T) {
-    return new GRef<T>(ref)
-  }
+    scalarType<I, O>(name: string, options?: ScalarOptions<I, O>) {
+        const t = new GScalar<I, O>(name, options)
+        this.types.push(t)
+        return t
+    }
 
-  // enum<T extends string>(args: T[]) {
-  //   return new GEnum<T>('', args)
-  // }
+    interface<N extends string, T extends AnyTypes>(name: N, shape: T) {
+        const t = new GInterface<N, T>(name, shape)
+        this.types.push(t)
+        return t
+    }
 
-  // union<T extends AnyType>(args: T[]) {
-  //   return new GUnion<T>('', args)
-  // }
+    string() {
+        return new GString<'String'>()
+    }
+
+    id() {
+        return new GString<'ID'>('ID')
+    }
+
+    int() {
+        return new GNumber<'Int'>('Int')
+    }
+
+    float() {
+        return new GNumber<'Float'>('Float')
+    }
+
+    boolean() {
+        return new GBoolean()
+    }
+
+    // The generic has to be any, because constraints cannot be applied to recursive types
+    // This is a limitation of TypeScript
+    ref<T>(ref: T) {
+        return new GRef<T>(ref)
+    }
+
+    // enum<T extends string>(args: T[]) {
+    //   return new GEnum<T>('', args)
+    // }
+
+    // union<T extends AnyType>(args: T[]) {
+    //   return new GUnion<T>('', args)
+    // }
 }
 
 export const g = new GarphSchema()

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -5,234 +5,359 @@ const factory = new Factory()
 const dataLoader = factory.create()
 
 export type ConverterConfig = {
-  defaultNullability?: boolean
+    defaultNullability?: boolean
 }
 
-export function printSchema(g: GarphSchema, config: ConverterConfig = { defaultNullability: false }) {
-  const schemaComposer = new SchemaComposer();
-  g.types.forEach(type => schemaComposer.add(convertToGraphqlType(schemaComposer, type.typeDef.name, type, config)))
-  return schemaComposer.toSDL()
+export function printSchema(
+    g: GarphSchema,
+    config: ConverterConfig = { defaultNullability: false }
+) {
+    const schemaComposer = new SchemaComposer()
+    g.types.forEach((type) =>
+        schemaComposer.add(
+            convertToGraphqlType(
+                schemaComposer,
+                type.typeDef.name,
+                type,
+                config
+            )
+        )
+    )
+    return schemaComposer.toSDL()
 }
 
-export function buildSchema({ g, resolvers }: { g: GarphSchema, resolvers?: any }, config: ConverterConfig = { defaultNullability: false }) {
-  const schemaComposer = new SchemaComposer();
-  g.types.forEach(type => schemaComposer.add(convertToGraphqlType(schemaComposer, type.typeDef.name, type, config, resolvers[type.typeDef.name])))
-  return schemaComposer.buildSchema()
+export function buildSchema(
+    { g, resolvers }: { g: GarphSchema; resolvers?: any },
+    config: ConverterConfig = { defaultNullability: false }
+) {
+    const schemaComposer = new SchemaComposer()
+    g.types.forEach((type) =>
+        schemaComposer.add(
+            convertToGraphqlType(
+                schemaComposer,
+                type.typeDef.name,
+                type,
+                config,
+                resolvers[type.typeDef.name]
+            )
+        )
+    )
+    return schemaComposer.buildSchema()
 }
 
 function isOptional(target: string, type: AnyType, config: ConverterConfig) {
-  return type.typeDef.isRequired ? `${target}!` : type.typeDef.isOptional ? `${target}` : config.defaultNullability ? `${target}` : `${target}!`
+    return type.typeDef.isRequired
+        ? `${target}!`
+        : type.typeDef.isOptional
+          ? `${target}`
+          : config.defaultNullability
+            ? `${target}`
+            : `${target}!`
 }
 
-export function getFieldType(schemaComposer: SchemaComposer, type: AnyType, config: ConverterConfig) {
-  switch (type.typeDef.type) {
-    case 'String':
-      return isOptional('String', type, config)
-    case 'Int':
-      return isOptional('Int', type, config)
-    case 'Float':
-      return isOptional('Float', type, config)
-    case 'Boolean':
-      return isOptional('Boolean', type, config)
-    case 'ID':
-      return isOptional('ID', type, config)
-    case 'List':
-      return isOptional(`[${getFieldType(schemaComposer, type.typeDef.shape, config)}]`, type, config)
-    case 'PaginatedList':
-      schemaComposer.createObjectTC({
-        name: `${type.typeDef.shape.typeDef.shape.typeDef.name}Edge`,
-        fields: {
-          node: {
-            type: type.typeDef.shape.typeDef.shape.typeDef.name,
-          },
-          cursor: {
-            type: 'String!',
-          }
+export function getFieldType(
+    schemaComposer: SchemaComposer,
+    type: AnyType,
+    config: ConverterConfig
+) {
+    switch (type.typeDef.type) {
+        case 'String':
+            return isOptional('String', type, config)
+        case 'Int':
+            return isOptional('Int', type, config)
+        case 'Float':
+            return isOptional('Float', type, config)
+        case 'Boolean':
+            return isOptional('Boolean', type, config)
+        case 'ID':
+            return isOptional('ID', type, config)
+        case 'List':
+            return isOptional(
+                `[${getFieldType(schemaComposer, type.typeDef.shape, config)}]`,
+                type,
+                config
+            )
+        case 'PaginatedList':
+            schemaComposer.createObjectTC({
+                name: `${type.typeDef.shape.typeDef.shape.typeDef.name}Edge`,
+                fields: {
+                    node: {
+                        type: type.typeDef.shape.typeDef.shape.typeDef.name,
+                    },
+                    cursor: {
+                        type: 'String!',
+                    },
+                },
+            })
+
+            schemaComposer.createObjectTC({
+                name: `${type.typeDef.shape.typeDef.shape.typeDef.name}Connection`,
+                fields: {
+                    edges: {
+                        type: `[${type.typeDef.shape.typeDef.shape.typeDef.name}Edge]`,
+                    },
+                    pageInfo: {
+                        type: 'PageInfo!',
+                    },
+                },
+            })
+
+            return isOptional(
+                `${type.typeDef.shape.typeDef.shape.typeDef.name}Connection`,
+                type,
+                config
+            )
+        case 'Ref':
+            if (!typeof type.typeDef.shape) {
+                throw new Error(
+                    'Ref type must be a function or a valid Garph Type'
+                )
+            }
+
+            let shape
+            if (typeof type.typeDef.shape === 'function') {
+                shape = type.typeDef.shape()
+            } else {
+                shape = type.typeDef.shape
+            }
+
+            return isOptional(shape.typeDef.name, type, config)
+        default:
+            return isOptional(type.typeDef.name, type, config)
+    }
+}
+
+export function convertToGraphqlType(
+    schemaComposer: SchemaComposer,
+    name: string,
+    type: AnyType,
+    config: ConverterConfig,
+    resolvers?: any
+) {
+    switch (type.typeDef.type) {
+        case 'ObjectType':
+            const objType = schemaComposer.createObjectTC({
+                name,
+                description: type.typeDef.description,
+                fields: parseFields(
+                    schemaComposer,
+                    name,
+                    type.typeDef.shape,
+                    config,
+                    resolvers
+                ),
+            })
+
+            if (type.typeDef.interfaces) {
+                type.typeDef.interfaces.forEach((i) => {
+                    objType.addFields(
+                        parseFields(
+                            schemaComposer,
+                            name,
+                            i.typeDef.shape,
+                            config,
+                            resolvers
+                        )
+                    )
+                    objType.addInterface(i.typeDef.name)
+                })
+            }
+
+            if (type.typeDef.extend) {
+                type.typeDef.extend.forEach((i) => {
+                    objType.addFields(
+                        parseFields(
+                            schemaComposer,
+                            name,
+                            i as any,
+                            config,
+                            resolvers
+                        )
+                    )
+                })
+            }
+
+            return objType
+        case 'Enum':
+            return schemaComposer.createEnumTC({
+                name,
+                description: type.typeDef.description,
+                values: type.typeDef.shape.reduce((acc, val) => {
+                    acc[val] = {}
+                    return acc
+                }, {}),
+            })
+        case 'Union':
+            return schemaComposer.createUnionTC({
+                name,
+                description: type.typeDef.description,
+                types: Object.values(type.typeDef.shape).map(
+                    (t: AnyType) => t.typeDef.name
+                ),
+                resolveType: resolvers?.resolveType,
+            })
+        case 'InputType':
+            const inputType = schemaComposer.createInputTC({
+                name,
+                description: type.typeDef.description,
+                fields: parseFields(
+                    schemaComposer,
+                    name,
+                    type.typeDef.shape,
+                    config
+                ),
+            })
+
+            if (type.typeDef.extend) {
+                type.typeDef.extend.forEach((i) => {
+                    inputType.addFields(
+                        parseFields(
+                            schemaComposer,
+                            name,
+                            i as any,
+                            config,
+                            resolvers
+                        )
+                    )
+                })
+            }
+
+            return inputType
+        case 'Scalar':
+            return schemaComposer.createScalarTC({
+                name,
+                description: type.typeDef.description,
+                serialize: type.typeDef.scalarOptions?.serialize,
+                parseValue: type.typeDef.scalarOptions?.parseValue,
+                parseLiteral: type.typeDef.scalarOptions?.parseLiteral,
+                specifiedByURL: type.typeDef.scalarOptions?.specifiedByUrl,
+            })
+        case 'InterfaceType':
+            const interfaceType = schemaComposer.createInterfaceTC({
+                name,
+                description: type.typeDef.description,
+                fields: parseFields(
+                    schemaComposer,
+                    name,
+                    type.typeDef.shape,
+                    config
+                ),
+                resolveType: resolvers?.resolveType,
+            })
+
+            if (type.typeDef.interfaces) {
+                type.typeDef.interfaces.forEach((i) => {
+                    interfaceType.addFields(
+                        parseFields(
+                            schemaComposer,
+                            name,
+                            i.typeDef.shape,
+                            config
+                        )
+                    )
+                    interfaceType.addInterface(i.typeDef.name)
+                })
+            }
+
+            if (type.typeDef.extend) {
+                type.typeDef.extend.forEach((i) => {
+                    interfaceType.addFields(
+                        parseFields(
+                            schemaComposer,
+                            name,
+                            i as any,
+                            config,
+                            resolvers
+                        )
+                    )
+                })
+            }
+
+            return interfaceType
+    }
+}
+
+export function parseFields(
+    schemaComposer: SchemaComposer,
+    name: string,
+    fields: AnyType,
+    config: ConverterConfig,
+    resolvers?: any
+) {
+    const fieldsObj = {}
+    Object.keys(fields).forEach((fieldName) => {
+        const field = fields[fieldName]
+
+        fieldsObj[fieldName] = {
+            type: getFieldType(schemaComposer, field, config),
+            args: parseArgs(schemaComposer, field.typeDef.args, config),
+            defaultValue: field.typeDef.defaultValue,
+            deprecationReason: field.typeDef.deprecated,
+            description: field.typeDef.description,
         }
-      })
 
-      schemaComposer.createObjectTC({
-        name: `${type.typeDef.shape.typeDef.shape.typeDef.name}Connection`,
-        fields: {
-          edges: {
-            type: `[${type.typeDef.shape.typeDef.shape.typeDef.name}Edge]`,
-          },
-          pageInfo: {
-            type: 'PageInfo!',
-          }
+        if (resolvers?.[fieldName]) {
+            Object.assign(
+                fieldsObj[fieldName],
+                addResolver(resolvers[fieldName], `${name}.${fieldName}`)
+            )
         }
-      })
+    })
 
-      return isOptional(`${type.typeDef.shape.typeDef.shape.typeDef.name}Connection`, type, config)
-    case 'Ref':
-      if (!typeof type.typeDef.shape) {
-        throw new Error('Ref type must be a function or a valid Garph Type')
-      }
-
-      let shape
-      if (typeof type.typeDef.shape === 'function') {
-        shape = type.typeDef.shape()
-      } else {
-        shape = type.typeDef.shape
-      }
-
-      return isOptional(shape.typeDef.name, type, config)
-    default:
-      return isOptional(type.typeDef.name, type, config)
-  }
+    return fieldsObj
 }
 
-export function convertToGraphqlType(schemaComposer: SchemaComposer, name: string, type: AnyType, config: ConverterConfig, resolvers?: any) {
-  switch (type.typeDef.type) {
-    case 'ObjectType':
-      const objType = schemaComposer.createObjectTC({
-        name,
-        description: type.typeDef.description,
-        fields: parseFields(schemaComposer, name, type.typeDef.shape, config, resolvers),
-      })
+function addResolver(resolver, cacheKey: string) {
+    if (!resolver) return
+    if (resolver.resolve || resolver.subscribe) return resolver
 
-      if (type.typeDef.interfaces) {
-        type.typeDef.interfaces.forEach(i => {
-          objType.addFields(parseFields(schemaComposer, name, i.typeDef.shape, config, resolvers))
-          objType.addInterface(i.typeDef.name)
-        })
-      }
+    // Loader
+    if (resolver.load) {
+        factory.add(cacheKey, { cache: true }, async (queries) =>
+            resolver.load(queries)
+        )
 
-      if (type.typeDef.extend) {
-        type.typeDef.extend.forEach(i => {
-          objType.addFields(parseFields(schemaComposer, name, i as any, config, resolvers))
-        })
-      }
+        return {
+            resolve: (parent, args, context, info) => {
+                return dataLoader[cacheKey]({ parent, args, context, info })
+            },
+        }
+    }
 
-      return objType
-    case 'Enum':
-      return schemaComposer.createEnumTC({
-        name,
-        description: type.typeDef.description,
-        values: type.typeDef.shape.reduce((acc, val) => {
-          acc[val] = {}
-          return acc
-        }, {})
-      })
-    case 'Union':
-      return schemaComposer.createUnionTC({
-        name,
-        description: type.typeDef.description,
-        types: Object.values(type.typeDef.shape).map((t: AnyType) => t.typeDef.name),
-        resolveType: resolvers?.resolveType
-      })
-    case 'InputType':
-      const inputType = schemaComposer.createInputTC({
-        name,
-        description: type.typeDef.description,
-        fields: parseFields(schemaComposer, name, type.typeDef.shape, config),
-      })
+    // Loader (no cache)
+    if (resolver.loadBatch) {
+        factory.add(cacheKey, { cache: false }, async (queries) =>
+            resolver.loadBatch(queries)
+        )
 
-      if (type.typeDef.extend) {
-        type.typeDef.extend.forEach(i => {
-          inputType.addFields(parseFields(schemaComposer, name, i as any, config, resolvers))
-        })
-      }
+        return {
+            resolve: (parent, args, context, info) => {
+                return dataLoader[cacheKey]({ parent, args, context, info })
+            },
+        }
+    }
 
-      return inputType
-    case 'Scalar':
-      return schemaComposer.createScalarTC({
-        name,
-        description: type.typeDef.description,
-        serialize: type.typeDef.scalarOptions?.serialize,
-        parseValue: type.typeDef.scalarOptions?.parseValue,
-        parseLiteral: type.typeDef.scalarOptions?.parseLiteral,
-        specifiedByURL: type.typeDef.scalarOptions?.specifiedByUrl
-      })
-    case 'InterfaceType':
-      const interfaceType = schemaComposer.createInterfaceTC({
-        name,
-        description: type.typeDef.description,
-        fields: parseFields(schemaComposer, name, type.typeDef.shape, config),
-        resolveType: resolvers?.resolveType
-      })
-
-      if (type.typeDef.interfaces) {
-        type.typeDef.interfaces.forEach(i => {
-          interfaceType.addFields(parseFields(schemaComposer, name, i.typeDef.shape, config))
-          interfaceType.addInterface(i.typeDef.name)
-        })
-      }
-
-      if (type.typeDef.extend) {
-        type.typeDef.extend.forEach(i => {
-          interfaceType.addFields(parseFields(schemaComposer, name, i as any, config, resolvers))
-        })
-      }
-
-      return interfaceType
-  }
+    return { resolve: resolver }
 }
 
-export function parseFields(schemaComposer: SchemaComposer, name: string, fields: AnyType, config: ConverterConfig, resolvers?: any) {
-  const fieldsObj = {}
-  Object.keys(fields).forEach(fieldName => {
-    const field = fields[fieldName]
+export function parseArgs(
+    schemaComposer: SchemaComposer,
+    anyArgs: Args,
+    config
+) {
+    if (!anyArgs) return
 
-    fieldsObj[fieldName] = {
-      type: getFieldType(schemaComposer, field, config),
-      args: parseArgs(schemaComposer, field.typeDef.args, config),
-      defaultValue: field.typeDef.defaultValue,
-      deprecationReason: field.typeDef.deprecated,
-      description: field.typeDef.description
-    }
+    const args = {}
 
-    if (resolvers?.[fieldName]) {
-      Object.assign(fieldsObj[fieldName], addResolver(resolvers[fieldName], `${name}.${fieldName}`))
-    }
-  })
+    Object.keys(anyArgs).forEach((argName) => {
+        const arg = anyArgs[argName]
+        args[argName] = {
+            type: getFieldType(schemaComposer, arg, config),
+            defaultValue: arg.typeDef.defaultValue,
+            deprecationReason: arg.typeDef.deprecated,
+            description: arg.typeDef.description,
+        }
+    })
 
-  return fieldsObj
-}
-
-function addResolver (resolver, cacheKey: string) {
-  if (!resolver) return
-  if (resolver.resolve || resolver.subscribe) return resolver
-
-  // Loader
-  if (resolver.load) {
-    factory.add(cacheKey, { cache: true }, async (queries) => resolver.load(queries))
-
-    return {
-      resolve: (parent, args, context, info) => {
-        return dataLoader[cacheKey]({ parent, args, context, info })
-      }
-    }
-  }
-
-  // Loader (no cache)
-  if (resolver.loadBatch) {
-    factory.add(cacheKey, { cache: false }, async (queries) => resolver.loadBatch(queries))
-
-    return {
-      resolve: (parent, args, context, info) => {
-        return dataLoader[cacheKey]({ parent, args, context, info })
-      }
-    }
-  }
-
-  return { resolve: resolver }
-}
-
-export function parseArgs(schemaComposer: SchemaComposer, anyArgs: Args, config) {
-  if (!anyArgs) return
-
-  const args = {}
-
-  Object.keys(anyArgs).forEach(argName => {
-    const arg = anyArgs[argName]
-    args[argName] = {
-      type: getFieldType(schemaComposer, arg, config),
-      defaultValue: arg.typeDef.defaultValue,
-      deprecationReason: arg.typeDef.deprecated,
-      description: arg.typeDef.description
-    }
-  })
-
-  return args
+    return args
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,15 @@
-export type UnionToIntersection<T> =
-  (T extends any ? (x: T) => any : never) extends
-  (x: infer R) => any ? R : never
+export type UnionToIntersection<T> = (
+    T extends any ? (x: T) => any : never
+) extends (x: infer R) => any
+    ? R
+    : never
 
 export type ArrayToEnum<T extends readonly any[]> = T[number]
 export type TSEnumType = { [s: number]: string }
 export type EnumToUnion<T extends TSEnumType> = keyof T
 
 export function getEnumProperties(enumValue: TSEnumType) {
-  return Object.keys(enumValue).filter((key) => isNaN(Number(key)))
+    return Object.keys(enumValue).filter((key) => isNaN(Number(key)))
 }
 
 export type ObjectToUnion<T> = T[keyof T]
@@ -16,8 +18,11 @@ export type MaybeFunction<T> = T | (() => T) | (() => Promise<T>)
 
 // Taken from Kysely
 // See the tweet: https://twitter.com/Riyaadh_Abr/status/1622736576303312899
-export type ExpandRecursively<T>
-  = T extends Record<string, unknown> | Record<string, unknown>[] | readonly Record<string, unknown>[]
-  ? T extends infer O
-  ? { [K in keyof O]: ExpandRecursively<O[K]> }
-  : never : T
+export type ExpandRecursively<T> = T extends
+    | Record<string, unknown>
+    | Record<string, unknown>[]
+    | readonly Record<string, unknown>[]
+    ? T extends infer O
+        ? { [K in keyof O]: ExpandRecursively<O[K]> }
+        : never
+    : T

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
-  "compilerOptions": {
-    "outDir": "dist",
-    "declaration": true,
-    "lib": ["ESNext", "DOM"],
-    "module": "NodeNext",
-    "target": "ESNext",
-    "moduleResolution": "NodeNext"
-  },
-  "include": ["src/**/*.ts"],
+    "compilerOptions": {
+        "outDir": "dist",
+        "declaration": true,
+        "lib": ["ESNext", "DOM"],
+        "module": "NodeNext",
+        "target": "ESNext",
+        "moduleResolution": "NodeNext"
+    },
+    "include": ["src/**/*.ts"]
 }

--- a/www/api/classes/GarphSchema.md
+++ b/www/api/classes/GarphSchema.md
@@ -10,10 +10,10 @@
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `«destructured»` | `Object` |
-| › `types` | [`AnyType`](../index.md#anytype)[] |
+| Name             | Type                               |
+| :--------------- | :--------------------------------- |
+| `«destructured»` | `Object`                           |
+| › `types`        | [`AnyType`](../index.md#anytype)[] |
 
 #### Defined in
 
@@ -23,13 +23,13 @@
 
 ### nodeType
 
-• **nodeType**: `GInterface`<``"Node"``, { `id`: `GString`<``"ID"``\>  }\>
+• **nodeType**: `GInterface`<`"Node"`, { `id`: `GString`<`"ID"`\> }\>
 
 #### Defined in
 
 [index.ts:600](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L600)
 
-___
+---
 
 ### pageInfoArgs
 
@@ -37,28 +37,28 @@ ___
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `after` | `GOptional`<`GString`<``"ID"``\>\> |
-| `before` | `GOptional`<`GString`<``"ID"``\>\> |
-| `first` | `GOptional`<`GNumber`<``"Int"``\>\> |
-| `last` | `GOptional`<`GNumber`<``"Int"``\>\> |
+| Name     | Type                              |
+| :------- | :-------------------------------- |
+| `after`  | `GOptional`<`GString`<`"ID"`\>\>  |
+| `before` | `GOptional`<`GString`<`"ID"`\>\>  |
+| `first`  | `GOptional`<`GNumber`<`"Int"`\>\> |
+| `last`   | `GOptional`<`GNumber`<`"Int"`\>\> |
 
 #### Defined in
 
 [index.ts:611](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L611)
 
-___
+---
 
 ### pageInfoType
 
-• **pageInfoType**: `GType`<``"PageInfo"``, { `endCursor`: `GOptional`<`GString`<``"String"``\>\> ; `hasNextPage`: `GBoolean` ; `hasPreviousPage`: `GBoolean` ; `startCursor`: `GOptional`<`GString`<``"String"``\>\>  }\>
+• **pageInfoType**: `GType`<`"PageInfo"`, { `endCursor`: `GOptional`<`GString`<`"String"`\>\> ; `hasNextPage`: `GBoolean` ; `hasPreviousPage`: `GBoolean` ; `startCursor`: `GOptional`<`GString`<`"String"`\>\> }\>
 
 #### Defined in
 
 [index.ts:604](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L604)
 
-___
+---
 
 ### types
 
@@ -82,63 +82,63 @@ ___
 
 [index.ts:703](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L703)
 
-___
+---
 
 ### connection
 
-▸ **connection**<`N`, `T`\>(`name`, `shape`): `GType`<`string`, { `edges`: `GList`<`T`\> ; `pageInfo`: `GType`<``"PageInfo"``, { `endCursor`: `GOptional`<`GString`<``"String"``\>\> ; `hasNextPage`: `GBoolean` ; `hasPreviousPage`: `GBoolean` ; `startCursor`: `GOptional`<`GString`<``"String"``\>\>  }\>  }\>
+▸ **connection**<`N`, `T`\>(`name`, `shape`): `GType`<`string`, { `edges`: `GList`<`T`\> ; `pageInfo`: `GType`<`"PageInfo"`, { `endCursor`: `GOptional`<`GString`<`"String"`\>\> ; `hasNextPage`: `GBoolean` ; `hasPreviousPage`: `GBoolean` ; `startCursor`: `GOptional`<`GString`<`"String"`\>\> }\> }\>
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `N` | extends `string` |
-| `T` | extends [`Type`](Type.md)<`any`, ``"Ref"``, `T`\> |
+| Name | Type                                            |
+| :--- | :---------------------------------------------- |
+| `N`  | extends `string`                                |
+| `T`  | extends [`Type`](Type.md)<`any`, `"Ref"`, `T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `N` |
-| `shape` | `T` |
+| Name    | Type |
+| :------ | :--- |
+| `name`  | `N`  |
+| `shape` | `T`  |
 
 #### Returns
 
-`GType`<`string`, { `edges`: `GList`<`T`\> ; `pageInfo`: `GType`<``"PageInfo"``, { `endCursor`: `GOptional`<`GString`<``"String"``\>\> ; `hasNextPage`: `GBoolean` ; `hasPreviousPage`: `GBoolean` ; `startCursor`: `GOptional`<`GString`<``"String"``\>\>  }\>  }\>
+`GType`<`string`, { `edges`: `GList`<`T`\> ; `pageInfo`: `GType`<`"PageInfo"`, { `endCursor`: `GOptional`<`GString`<`"String"`\>\> ; `hasNextPage`: `GBoolean` ; `hasPreviousPage`: `GBoolean` ; `startCursor`: `GOptional`<`GString`<`"String"`\>\> }\> }\>
 
 #### Defined in
 
 [index.ts:634](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L634)
 
-___
+---
 
 ### edge
 
-▸ **edge**<`N`, `T`\>(`name`, `shape`): `GType`<`N`, { `cursor`: [`AnyString`](../index.md#anystring) ; `node`: `T`  }\>
+▸ **edge**<`N`, `T`\>(`name`, `shape`): `GType`<`N`, { `cursor`: [`AnyString`](../index.md#anystring) ; `node`: `T` }\>
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `N` | extends `string` |
-| `T` | extends [`Type`](Type.md)<`any`, ``"Ref"``, `T`\> |
+| Name | Type                                            |
+| :--- | :---------------------------------------------- |
+| `N`  | extends `string`                                |
+| `T`  | extends [`Type`](Type.md)<`any`, `"Ref"`, `T`\> |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `N` |
-| `shape` | `T` |
+| Name    | Type |
+| :------ | :--- |
+| `name`  | `N`  |
+| `shape` | `T`  |
 
 #### Returns
 
-`GType`<`N`, { `cursor`: [`AnyString`](../index.md#anystring) ; `node`: `T`  }\>
+`GType`<`N`, { `cursor`: [`AnyString`](../index.md#anystring) ; `node`: `T` }\>
 
 #### Defined in
 
 [index.ts:644](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L644)
 
-___
+---
 
 ### enumType
 
@@ -146,17 +146,17 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `N` | extends `string` |
-| `T` | extends readonly `string`[] \| `TSEnumType` |
+| Name | Type                                        |
+| :--- | :------------------------------------------ |
+| `N`  | extends `string`                            |
+| `T`  | extends readonly `string`[] \| `TSEnumType` |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `N` |
-| `args` | `T` |
+| Name   | Type |
+| :----- | :--- |
+| `name` | `N`  |
+| `args` | `T`  |
 
 #### Returns
 
@@ -166,35 +166,35 @@ ___
 
 [index.ts:663](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L663)
 
-___
+---
 
 ### float
 
-▸ **float**(): `GNumber`<``"Float"``\>
+▸ **float**(): `GNumber`<`"Float"`\>
 
 #### Returns
 
-`GNumber`<``"Float"``\>
+`GNumber`<`"Float"`\>
 
 #### Defined in
 
 [index.ts:699](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L699)
 
-___
+---
 
 ### id
 
-▸ **id**(): `GString`<``"ID"``\>
+▸ **id**(): `GString`<`"ID"`\>
 
 #### Returns
 
-`GString`<``"ID"``\>
+`GString`<`"ID"`\>
 
 #### Defined in
 
 [index.ts:691](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L691)
 
-___
+---
 
 ### inputType
 
@@ -202,17 +202,17 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `N` | extends `string` |
-| `T` | extends [`AnyTypes`](../index.md#anytypes) |
+| Name | Type                                       |
+| :--- | :----------------------------------------- |
+| `N`  | extends `string`                           |
+| `T`  | extends [`AnyTypes`](../index.md#anytypes) |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `N` |
-| `shape` | `T` |
+| Name    | Type |
+| :------ | :--- |
+| `name`  | `N`  |
+| `shape` | `T`  |
 
 #### Returns
 
@@ -222,21 +222,21 @@ ___
 
 [index.ts:657](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L657)
 
-___
+---
 
 ### int
 
-▸ **int**(): `GNumber`<``"Int"``\>
+▸ **int**(): `GNumber`<`"Int"`\>
 
 #### Returns
 
-`GNumber`<``"Int"``\>
+`GNumber`<`"Int"`\>
 
 #### Defined in
 
 [index.ts:695](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L695)
 
-___
+---
 
 ### interface
 
@@ -244,17 +244,17 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `N` | extends `string` |
-| `T` | extends [`AnyTypes`](../index.md#anytypes) |
+| Name | Type                                       |
+| :--- | :----------------------------------------- |
+| `N`  | extends `string`                           |
+| `T`  | extends [`AnyTypes`](../index.md#anytypes) |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `N` |
-| `shape` | `T` |
+| Name    | Type |
+| :------ | :--- |
+| `name`  | `N`  |
+| `shape` | `T`  |
 
 #### Returns
 
@@ -264,35 +264,35 @@ ___
 
 [index.ts:681](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L681)
 
-___
+---
 
 ### node
 
-▸ **node**<`N`, `T`\>(`name`, `shape`): `GType`<`N`, `T` & { `id`: `GString`<``"ID"``\>  }\>
+▸ **node**<`N`, `T`\>(`name`, `shape`): `GType`<`N`, `T` & { `id`: `GString`<`"ID"`\> }\>
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `N` | extends `string` |
-| `T` | extends [`AnyTypes`](../index.md#anytypes) |
+| Name | Type                                       |
+| :--- | :----------------------------------------- |
+| `N`  | extends `string`                           |
+| `T`  | extends [`AnyTypes`](../index.md#anytypes) |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `N` |
-| `shape` | `T` |
+| Name    | Type |
+| :------ | :--- |
+| `name`  | `N`  |
+| `shape` | `T`  |
 
 #### Returns
 
-`GType`<`N`, `T` & { `id`: `GString`<``"ID"``\>  }\>
+`GType`<`N`, `T` & { `id`: `GString`<`"ID"`\> }\>
 
 #### Defined in
 
 [index.ts:628](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L628)
 
-___
+---
 
 ### ref
 
@@ -301,14 +301,14 @@ ___
 #### Type parameters
 
 | Name |
-| :------ |
-| `T` |
+| :--- |
+| `T`  |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `ref` | `T` |
+| Name  | Type |
+| :---- | :--- |
+| `ref` | `T`  |
 
 #### Returns
 
@@ -318,7 +318,7 @@ ___
 
 [index.ts:709](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L709)
 
-___
+---
 
 ### scalarType
 
@@ -327,15 +327,15 @@ ___
 #### Type parameters
 
 | Name |
-| :------ |
-| `I` |
-| `O` |
+| :--- |
+| `I`  |
+| `O`  |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `string` |
+| Name       | Type                       |
+| :--------- | :------------------------- |
+| `name`     | `string`                   |
 | `options?` | `ScalarOptions`<`I`, `O`\> |
 
 #### Returns
@@ -346,21 +346,21 @@ ___
 
 [index.ts:675](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L675)
 
-___
+---
 
 ### string
 
-▸ **string**(): `GString`<``"String"``\>
+▸ **string**(): `GString`<`"String"`\>
 
 #### Returns
 
-`GString`<``"String"``\>
+`GString`<`"String"`\>
 
 #### Defined in
 
 [index.ts:687](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L687)
 
-___
+---
 
 ### type
 
@@ -368,17 +368,17 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `N` | extends `string` |
-| `T` | extends [`AnyTypes`](../index.md#anytypes) |
+| Name | Type                                       |
+| :--- | :----------------------------------------- |
+| `N`  | extends `string`                           |
+| `T`  | extends [`AnyTypes`](../index.md#anytypes) |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `N` |
-| `shape` | `T` |
+| Name    | Type |
+| :------ | :--- |
+| `name`  | `N`  |
+| `shape` | `T`  |
 
 #### Returns
 
@@ -388,7 +388,7 @@ ___
 
 [index.ts:622](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L622)
 
-___
+---
 
 ### unionType
 
@@ -396,17 +396,17 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `N` | extends `string` |
-| `T` | extends [`AnyObjects`](../index.md#anyobjects) |
+| Name | Type                                           |
+| :--- | :--------------------------------------------- |
+| `N`  | extends `string`                               |
+| `T`  | extends [`AnyObjects`](../index.md#anyobjects) |
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | `N` |
-| `args` | `T` |
+| Name   | Type |
+| :----- | :--- |
+| `name` | `N`  |
+| `args` | `T`  |
 
 #### Returns
 

--- a/www/api/classes/Type.md
+++ b/www/api/classes/Type.md
@@ -4,10 +4,10 @@
 
 ## Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `T` |
-| `X` | extends `GarphType` |
+| Name | Type                |
+| :--- | :------------------ |
+| `T`  | `T`                 |
+| `X`  | extends `GarphType` |
 
 ## Constructors
 
@@ -17,10 +17,10 @@
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `T` |
-| `X` | extends `GarphType` |
+| Name | Type                |
+| :--- | :------------------ |
+| `T`  | `T`                 |
+| `X`  | extends `GarphType` |
 
 ## Properties
 
@@ -32,7 +32,7 @@
 
 [index.ts:13](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L13)
 
-___
+---
 
 ### \_inner
 
@@ -42,7 +42,7 @@ ___
 
 [index.ts:11](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L11)
 
-___
+---
 
 ### \_is
 
@@ -52,7 +52,7 @@ ___
 
 [index.ts:10](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L10)
 
-___
+---
 
 ### \_name
 
@@ -62,7 +62,7 @@ ___
 
 [index.ts:9](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L9)
 
-___
+---
 
 ### \_output
 
@@ -72,7 +72,7 @@ ___
 
 [index.ts:12](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L12)
 
-___
+---
 
 ### \_shape
 
@@ -82,7 +82,7 @@ ___
 
 [index.ts:14](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L14)
 
-___
+---
 
 ### typeDef
 
@@ -100,8 +100,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name     | Type     |
+| :------- | :------- |
 | `reason` | `string` |
 
 #### Returns
@@ -112,7 +112,7 @@ ___
 
 [index.ts:22](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L22)
 
-___
+---
 
 ### description
 
@@ -120,8 +120,8 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
+| Name   | Type     |
+| :----- | :------- |
 | `text` | `string` |
 
 #### Returns

--- a/www/api/index.md
+++ b/www/api/index.md
@@ -4,100 +4,100 @@ garph
 
 ## Classes
 
-- [GarphSchema](classes/GarphSchema.md)
-- [Type](classes/Type.md)
+-   [GarphSchema](classes/GarphSchema.md)
+-   [Type](classes/Type.md)
 
 ## Type Aliases
 
 ### AnyArgs
 
-Ƭ **AnyArgs**: [`Type`](classes/Type.md)<`any`, ``"Args"``\>
+Ƭ **AnyArgs**: [`Type`](classes/Type.md)<`any`, `"Args"`\>
 
 #### Defined in
 
 [index.ts:58](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L58)
 
-___
+---
 
 ### AnyBoolean
 
-Ƭ **AnyBoolean**: [`Type`](classes/Type.md)<`boolean`, ``"Boolean"``\>
+Ƭ **AnyBoolean**: [`Type`](classes/Type.md)<`boolean`, `"Boolean"`\>
 
 #### Defined in
 
 [index.ts:46](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L46)
 
-___
+---
 
 ### AnyEnum
 
-Ƭ **AnyEnum**: [`Type`](classes/Type.md)<`any`, ``"Enum"``\>
+Ƭ **AnyEnum**: [`Type`](classes/Type.md)<`any`, `"Enum"`\>
 
 #### Defined in
 
 [index.ts:54](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L54)
 
-___
+---
 
 ### AnyFloat
 
-Ƭ **AnyFloat**: [`Type`](classes/Type.md)<`number`, ``"Float"``\>
+Ƭ **AnyFloat**: [`Type`](classes/Type.md)<`number`, `"Float"`\>
 
 #### Defined in
 
 [index.ts:49](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L49)
 
-___
+---
 
 ### AnyID
 
-Ƭ **AnyID**: [`Type`](classes/Type.md)<`string`, ``"ID"``\>
+Ƭ **AnyID**: [`Type`](classes/Type.md)<`string`, `"ID"`\>
 
 #### Defined in
 
 [index.ts:45](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L45)
 
-___
+---
 
 ### AnyInput
 
-Ƭ **AnyInput**: [`Type`](classes/Type.md)<`any`, ``"InputType"``\>
+Ƭ **AnyInput**: [`Type`](classes/Type.md)<`any`, `"InputType"`\>
 
 #### Defined in
 
 [index.ts:56](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L56)
 
-___
+---
 
 ### AnyInt
 
-Ƭ **AnyInt**: [`Type`](classes/Type.md)<`number`, ``"Int"``\>
+Ƭ **AnyInt**: [`Type`](classes/Type.md)<`number`, `"Int"`\>
 
 #### Defined in
 
 [index.ts:48](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L48)
 
-___
+---
 
 ### AnyInterface
 
-Ƭ **AnyInterface**: [`Type`](classes/Type.md)<`any`, ``"InterfaceType"``\>
+Ƭ **AnyInterface**: [`Type`](classes/Type.md)<`any`, `"InterfaceType"`\>
 
 #### Defined in
 
 [index.ts:57](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L57)
 
-___
+---
 
 ### AnyList
 
-Ƭ **AnyList**: [`Type`](classes/Type.md)<`any`, ``"List"``\>
+Ƭ **AnyList**: [`Type`](classes/Type.md)<`any`, `"List"`\>
 
 #### Defined in
 
 [index.ts:51](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L51)
 
-___
+---
 
 ### AnyNumber
 
@@ -107,17 +107,17 @@ ___
 
 [index.ts:47](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L47)
 
-___
+---
 
 ### AnyObject
 
-Ƭ **AnyObject**: [`Type`](classes/Type.md)<`any`, ``"ObjectType"``\>
+Ƭ **AnyObject**: [`Type`](classes/Type.md)<`any`, `"ObjectType"`\>
 
 #### Defined in
 
 [index.ts:60](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L60)
 
-___
+---
 
 ### AnyObjects
 
@@ -131,67 +131,67 @@ ___
 
 [index.ts:71](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L71)
 
-___
+---
 
 ### AnyOmitResolver
 
-Ƭ **AnyOmitResolver**: [`Type`](classes/Type.md)<`any`, ``"OmitResolver"``\>
+Ƭ **AnyOmitResolver**: [`Type`](classes/Type.md)<`any`, `"OmitResolver"`\>
 
 #### Defined in
 
 [index.ts:61](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L61)
 
-___
+---
 
 ### AnyOptional
 
-Ƭ **AnyOptional**: [`Type`](classes/Type.md)<`any`, ``"Optional"``\>
+Ƭ **AnyOptional**: [`Type`](classes/Type.md)<`any`, `"Optional"`\>
 
 #### Defined in
 
 [index.ts:59](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L59)
 
-___
+---
 
 ### AnyPaginatedList
 
-Ƭ **AnyPaginatedList**: [`Type`](classes/Type.md)<`any`, ``"PaginatedList"``\>
+Ƭ **AnyPaginatedList**: [`Type`](classes/Type.md)<`any`, `"PaginatedList"`\>
 
 #### Defined in
 
 [index.ts:52](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L52)
 
-___
+---
 
 ### AnyRef
 
-Ƭ **AnyRef**: [`Type`](classes/Type.md)<`any`, ``"Ref"``\>
+Ƭ **AnyRef**: [`Type`](classes/Type.md)<`any`, `"Ref"`\>
 
 #### Defined in
 
 [index.ts:50](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L50)
 
-___
+---
 
 ### AnyScalar
 
-Ƭ **AnyScalar**: [`Type`](classes/Type.md)<`any`, ``"Scalar"``\>
+Ƭ **AnyScalar**: [`Type`](classes/Type.md)<`any`, `"Scalar"`\>
 
 #### Defined in
 
 [index.ts:55](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L55)
 
-___
+---
 
 ### AnyString
 
-Ƭ **AnyString**: [`Type`](classes/Type.md)<`string`, ``"String"``\>
+Ƭ **AnyString**: [`Type`](classes/Type.md)<`string`, `"String"`\>
 
 #### Defined in
 
 [index.ts:44](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L44)
 
-___
+---
 
 ### AnyType
 
@@ -201,7 +201,7 @@ ___
 
 [index.ts:43](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L43)
 
-___
+---
 
 ### AnyTypes
 
@@ -215,17 +215,17 @@ ___
 
 [index.ts:67](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L67)
 
-___
+---
 
 ### AnyUnion
 
-Ƭ **AnyUnion**: [`Type`](classes/Type.md)<`any`, ``"Union"``\>
+Ƭ **AnyUnion**: [`Type`](classes/Type.md)<`any`, `"Union"`\>
 
 #### Defined in
 
 [index.ts:53](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L53)
 
-___
+---
 
 ### Args
 
@@ -239,7 +239,7 @@ ___
 
 [index.ts:63](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L63)
 
-___
+---
 
 ### Infer
 
@@ -247,16 +247,16 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `T` |
-| `options` | extends `InferOptions` = { `omitResolver`: `never`  } |
+| Name      | Type                                                 |
+| :-------- | :--------------------------------------------------- |
+| `T`       | `T`                                                  |
+| `options` | extends `InferOptions` = { `omitResolver`: `never` } |
 
 #### Defined in
 
 [index.ts:93](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L93)
 
-___
+---
 
 ### InferArg
 
@@ -265,14 +265,14 @@ ___
 #### Type parameters
 
 | Name |
-| :------ |
-| `T` |
+| :--- |
+| `T`  |
 
 #### Defined in
 
 [index.ts:125](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L125)
 
-___
+---
 
 ### InferArgRaw
 
@@ -281,14 +281,14 @@ ___
 #### Type parameters
 
 | Name |
-| :------ |
-| `T` |
+| :--- |
+| `T`  |
 
 #### Defined in
 
 [index.ts:126](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L126)
 
-___
+---
 
 ### InferArgs
 
@@ -296,15 +296,15 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | extends [`AnyType`](index.md#anytype) |
+| Name | Type                                  |
+| :--- | :------------------------------------ |
+| `T`  | extends [`AnyType`](index.md#anytype) |
 
 #### Defined in
 
 [index.ts:120](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L120)
 
-___
+---
 
 ### InferArgsRaw
 
@@ -312,32 +312,32 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | extends [`AnyType`](index.md#anytype) |
+| Name | Type                                  |
+| :--- | :------------------------------------ |
+| `T`  | extends [`AnyType`](index.md#anytype) |
 
 #### Defined in
 
 [index.ts:121](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L121)
 
-___
+---
 
 ### InferRaw
 
-Ƭ **InferRaw**<`T`, `options`\>: `T` extends [`AnyInput`](index.md#anyinput) \| [`AnyObject`](index.md#anyobject) \| [`AnyInterface`](index.md#anyinterface) ? { `__typename?`: `T`[``"_name"``]  } & { [K in keyof T["\_shape"] as T["\_shape"][K] extends AnyOptional \| options["omitResolver"] ? never : T["\_shape"][K] extends AnyArgs ? T["\_shape"][K]["\_shape"] extends AnyOptional \| options["omitResolver"] ? never : K : K]: InferRaw<T["\_shape"][K], options\> } & { [K in keyof T["\_shape"] as T["\_shape"][K] extends AnyOptional \| options["omitResolver"] ? K : T["\_shape"][K] extends AnyArgs ? T["\_shape"][K]["\_shape"] extends AnyOptional \| options["omitResolver"] ? K : never : never]?: InferRaw<T["\_shape"][K], options\> } : [`InferShallow`](index.md#infershallow)<`T`, `options`\>
+Ƭ **InferRaw**<`T`, `options`\>: `T` extends [`AnyInput`](index.md#anyinput) \| [`AnyObject`](index.md#anyobject) \| [`AnyInterface`](index.md#anyinterface) ? { `__typename?`: `T`[``"_name"``] } & { [K in keyof T["\_shape"] as T["\_shape"][K] extends AnyOptional \| options["omitResolver"] ? never : T["\_shape"][K] extends AnyArgs ? T["\_shape"][K]["\_shape"] extends AnyOptional \| options["omitResolver"] ? never : K : K]: InferRaw<T["\_shape"][K], options\> } & { [K in keyof T["\_shape"] as T["\_shape"][K] extends AnyOptional \| options["omitResolver"] ? K : T["\_shape"][K] extends AnyArgs ? T["\_shape"][K]["\_shape"] extends AnyOptional \| options["omitResolver"] ? K : never : never]?: InferRaw<T["\_shape"][K], options\> } : [`InferShallow`](index.md#infershallow)<`T`, `options`\>
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `T` |
-| `options` | extends `InferOptions` = { `omitResolver`: `never`  } |
+| Name      | Type                                                 |
+| :-------- | :--------------------------------------------------- |
+| `T`       | `T`                                                  |
+| `options` | extends `InferOptions` = { `omitResolver`: `never` } |
 
 #### Defined in
 
 [index.ts:94](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L94)
 
-___
+---
 
 ### InferResolvers
 
@@ -345,16 +345,16 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | extends [`AnyTypes`](index.md#anytypes) |
-| `X` | extends `InferResolverConfig` |
+| Name | Type                                    |
+| :--- | :-------------------------------------- |
+| `T`  | extends [`AnyTypes`](index.md#anytypes) |
+| `X`  | extends `InferResolverConfig`           |
 
 #### Defined in
 
 [index.ts:134](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L134)
 
-___
+---
 
 ### InferResolversStrict
 
@@ -362,33 +362,33 @@ ___
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | extends [`AnyTypes`](index.md#anytypes) |
-| `X` | extends `InferResolverConfig` |
+| Name | Type                                    |
+| :--- | :-------------------------------------- |
+| `T`  | extends [`AnyTypes`](index.md#anytypes) |
+| `X`  | extends `InferResolverConfig`           |
 
 #### Defined in
 
 [index.ts:156](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L156)
 
-___
+---
 
 ### InferShallow
 
-Ƭ **InferShallow**<`T`, `options`\>: `T` extends [`AnyString`](index.md#anystring) \| [`AnyID`](index.md#anyid) \| [`AnyScalar`](index.md#anyscalar) \| [`AnyNumber`](index.md#anynumber) \| [`AnyBoolean`](index.md#anyboolean) ? `T`[``"_shape"``] : `T` extends [`AnyEnum`](index.md#anyenum) ? `T`[``"_inner"``] : `T` extends [`AnyUnion`](index.md#anyunion) ? [`InferRaw`](index.md#inferraw)<`ObjectToUnion`<`T`[``"_inner"``]\>, `options`\> : `T` extends [`AnyList`](index.md#anylist) ? [`InferRaw`](index.md#inferraw)<`T`[``"_shape"``], `options`\>[] : `T` extends [`AnyPaginatedList`](index.md#anypaginatedlist) ? `T`[``"_inner"``] : `T` extends [`AnyOptional`](index.md#anyoptional) ? [`InferRaw`](index.md#inferraw)<`T`[``"_shape"``], `options`\> \| ``null`` \| `undefined` : `T` extends [`AnyOmitResolver`](index.md#anyomitresolver) ? [`InferRaw`](index.md#inferraw)<`T`[``"_shape"``], `options`\> : `T` extends [`AnyArgs`](index.md#anyargs) ? [`InferRaw`](index.md#inferraw)<`T`[``"_shape"``], `options`\> : `T` extends [`AnyRef`](index.md#anyref) ? [`InferRaw`](index.md#inferraw)<`T`[``"_inner"``], `options`\> : `T`
+Ƭ **InferShallow**<`T`, `options`\>: `T` extends [`AnyString`](index.md#anystring) \| [`AnyID`](index.md#anyid) \| [`AnyScalar`](index.md#anyscalar) \| [`AnyNumber`](index.md#anynumber) \| [`AnyBoolean`](index.md#anyboolean) ? `T`[``"_shape"``] : `T` extends [`AnyEnum`](index.md#anyenum) ? `T`[``"_inner"``] : `T` extends [`AnyUnion`](index.md#anyunion) ? [`InferRaw`](index.md#inferraw)<`ObjectToUnion`<`T`[``"_inner"``]\>, `options`\> : `T` extends [`AnyList`](index.md#anylist) ? [`InferRaw`](index.md#inferraw)<`T`[``"_shape"``], `options`\>[] : `T` extends [`AnyPaginatedList`](index.md#anypaginatedlist) ? `T`[``"_inner"``] : `T` extends [`AnyOptional`](index.md#anyoptional) ? [`InferRaw`](index.md#inferraw)<`T`[``"_shape"``], `options`\> \| `null` \| `undefined` : `T` extends [`AnyOmitResolver`](index.md#anyomitresolver) ? [`InferRaw`](index.md#inferraw)<`T`[``"_shape"``], `options`\> : `T` extends [`AnyArgs`](index.md#anyargs) ? [`InferRaw`](index.md#inferraw)<`T`[``"_shape"``], `options`\> : `T` extends [`AnyRef`](index.md#anyref) ? [`InferRaw`](index.md#inferraw)<`T`[``"_inner"``], `options`\> : `T`
 
 #### Type parameters
 
-| Name | Type |
-| :------ | :------ |
-| `T` | `T` |
-| `options` | extends `InferOptions` = { `omitResolver`: `never`  } |
+| Name      | Type                                                 |
+| :-------- | :--------------------------------------------------- |
+| `T`       | `T`                                                  |
+| `options` | extends `InferOptions` = { `omitResolver`: `never` } |
 
 #### Defined in
 
 [index.ts:108](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L108)
 
-___
+---
 
 ### InferUnionNames
 
@@ -397,14 +397,14 @@ ___
 #### Type parameters
 
 | Name |
-| :------ |
-| `T` |
+| :--- |
+| `T`  |
 
 #### Defined in
 
 [index.ts:132](https://github.com/stepci/garph/blob/3c68aab/src/index.ts#L132)
 
-___
+---
 
 ### TypeDefinition
 
@@ -413,25 +413,25 @@ ___
 #### Type parameters
 
 | Name |
-| :------ |
-| `T` |
+| :--- |
+| `T`  |
 
 #### Type declaration
 
-| Name | Type |
-| :------ | :------ |
-| `args?` | [`Args`](index.md#args) |
-| `defaultValue?` | `any` |
-| `deprecated?` | `string` |
-| `description?` | `string` |
-| `extend?` | [`AnyTypes`](index.md#anytypes)[] |
-| `interfaces?` | [`AnyInterface`](index.md#anyinterface)[] |
-| `isOptional?` | `boolean` |
-| `isRequired?` | `boolean` |
-| `name?` | `string` |
-| `scalarOptions?` | `ScalarOptions`<`any`, `any`\> |
-| `shape?` | `T` |
-| `type` | `GarphType` |
+| Name             | Type                                      |
+| :--------------- | :---------------------------------------- |
+| `args?`          | [`Args`](index.md#args)                   |
+| `defaultValue?`  | `any`                                     |
+| `deprecated?`    | `string`                                  |
+| `description?`   | `string`                                  |
+| `extend?`        | [`AnyTypes`](index.md#anytypes)[]         |
+| `interfaces?`    | [`AnyInterface`](index.md#anyinterface)[] |
+| `isOptional?`    | `boolean`                                 |
+| `isRequired?`    | `boolean`                                 |
+| `name?`          | `string`                                  |
+| `scalarOptions?` | `ScalarOptions`<`any`, `any`\>            |
+| `shape?`         | `T`                                       |
+| `type`           | `GarphType`                               |
 
 #### Defined in
 
@@ -455,12 +455,12 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `«destructured»` | `Object` |
-| › `g` | [`GarphSchema`](classes/GarphSchema.md) |
-| › `resolvers?` | `any` |
-| `config` | `ConverterConfig` |
+| Name             | Type                                    |
+| :--------------- | :-------------------------------------- |
+| `«destructured»` | `Object`                                |
+| › `g`            | [`GarphSchema`](classes/GarphSchema.md) |
+| › `resolvers?`   | `any`                                   |
+| `config`         | `ConverterConfig`                       |
 
 #### Returns
 
@@ -470,7 +470,7 @@ ___
 
 [schema.ts:17](https://github.com/stepci/garph/blob/3c68aab/src/schema.ts#L17)
 
-___
+---
 
 ### printSchema
 
@@ -478,10 +478,10 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `g` | [`GarphSchema`](classes/GarphSchema.md) |
-| `config` | `ConverterConfig` |
+| Name     | Type                                    |
+| :------- | :-------------------------------------- |
+| `g`      | [`GarphSchema`](classes/GarphSchema.md) |
+| `config` | `ConverterConfig`                       |
 
 #### Returns
 

--- a/www/docs/advanced/context.md
+++ b/www/docs/advanced/context.md
@@ -11,13 +11,16 @@ import { g, InferResolvers, buildSchema } from 'garph'
 import { createYoga, YogaInitialContext } from 'graphql-yoga'
 
 const queryType = g.type('Query', {
-  context: g.string()
+    context: g.string(),
 })
 
-const resolvers: InferResolvers<{ Query: typeof queryType }, { context: YogaInitialContext }> = {
-  Query: {
-    context: (parent, args, context, info) => `Context: ${context}`
-  }
+const resolvers: InferResolvers<
+    { Query: typeof queryType },
+    { context: YogaInitialContext }
+> = {
+    Query: {
+        context: (parent, args, context, info) => `Context: ${context}`,
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
@@ -32,19 +35,22 @@ import { g, InferResolvers, buildSchema } from 'garph'
 import { createYoga, YogaInitialContext } from 'graphql-yoga'
 
 const queryType = g.type('Query', {
-  context: g.string()
+    context: g.string(),
 })
 
 const context = () => {
-  return {
-    hello: 'world'
-  }
+    return {
+        hello: 'world',
+    }
 }
 
-const resolvers: InferResolvers<{ Query: typeof queryType }, { context: YogaInitialContext & ReturnType<typeof context> }> = {
-  Query: {
-    context: (parent, args, context, info) => `Context: ${context.hello}`
-  }
+const resolvers: InferResolvers<
+    { Query: typeof queryType },
+    { context: YogaInitialContext & ReturnType<typeof context> }
+> = {
+    Query: {
+        context: (parent, args, context, info) => `Context: ${context.hello}`,
+    },
 }
 
 const schema = buildSchema({ g, resolvers })

--- a/www/docs/advanced/defer-stream.md
+++ b/www/docs/advanced/defer-stream.md
@@ -9,6 +9,7 @@ Stream and defer are directives that allow you to improve latency for clients by
 Install a yoga plugin to enable `@stream` and `@defer` directives (requires yoga v4 and higer)
 
 ::: code-group
+
 ```sh [npm]
 $ npm i @graphql-yoga/plugin-defer-stream
 ```
@@ -24,6 +25,7 @@ $ yarn add @graphql-yoga/plugin-defer-stream
 ```sh [bun]
 $ bun i @graphql-yoga/plugin-defer-stream
 ```
+
 :::
 
 Example Garph schema with streamed and slow fields:
@@ -35,50 +37,51 @@ import { useDeferStream } from '@graphql-yoga/plugin-defer-stream'
 import { createServer } from 'node:http'
 
 const queryType = g.type('Query', {
-  alphabet: g.string().list().description(`This field can be @stream'ed`),
-  fastField: g.string().description('A field that resolves fast.'),
-  slowField: g
-    .string()
-    .optional()
-    .description(
-      'A field that resolves slowly. Maybe you want to @defer this field ;)'
-    )
-    .args({
-      waitFor: g.int().default(5000),
-    })
+    alphabet: g.string().list().description(`This field can be @stream'ed`),
+    fastField: g.string().description('A field that resolves fast.'),
+    slowField: g
+        .string()
+        .optional()
+        .description(
+            'A field that resolves slowly. Maybe you want to @defer this field ;)'
+        )
+        .args({
+            waitFor: g.int().default(5000),
+        }),
 })
 
-const wait = (time: number) => new Promise(resolve => setTimeout(resolve, time))
+const wait = (time: number) =>
+    new Promise((resolve) => setTimeout(resolve, time))
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    async *alphabet() {
-      for (const character of ['a', 'b', 'c', 'd', 'e', 'f', 'g']) {
-        yield character
-        await wait(1000)
-      }
+    Query: {
+        async *alphabet() {
+            for (const character of ['a', 'b', 'c', 'd', 'e', 'f', 'g']) {
+                yield character
+                await wait(1000)
+            }
+        },
+        fastField: async () => {
+            await wait(100)
+            return 'I am speed'
+        },
+        slowField: async (_, { waitFor }) => {
+            await wait(waitFor)
+            return 'I am slow'
+        },
     },
-    fastField: async () => {
-      await wait(100)
-      return 'I am speed'
-    },
-    slowField: async (_, { waitFor }) => {
-      await wait(waitFor)
-      return 'I am slow'
-    }
-  }
 }
 
 const schema = buildSchema({ g, resolvers })
 const yoga = createYoga({
-  schema,
-  plugins: [useDeferStream()]
+    schema,
+    plugins: [useDeferStream()],
 })
 
 const server = createServer(yoga)
 
 server.listen(4000, () => {
-  console.info('Server is running on http://localhost:4000/graphql')
+    console.info('Server is running on http://localhost:4000/graphql')
 })
 ```
 
@@ -96,7 +99,7 @@ Visit http://localhost:4000/graphql and paste the following operation into the l
 
 ```graphql
 query StreamAlphabet {
-  alphabet @stream
+    alphabet @stream
 }
 ```
 
@@ -120,10 +123,10 @@ Visit http://localhost:4000/graphql and paste the following operation into the l
 
 ```graphql
 query SlowAndFastFieldWithDefer {
-  ... on Query @defer {
-    slowField
-  }
-  fastField
+    ... on Query @defer {
+        slowField
+    }
+    fastField
 }
 ```
 

--- a/www/docs/advanced/errors.md
+++ b/www/docs/advanced/errors.md
@@ -11,15 +11,15 @@ import { g, InferResolvers, buildSchema } from 'garph'
 import { GraphQLError } from 'graphql'
 
 const queryType = g.type('Query', {
-  error: g.string(),
+    error: g.string(),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    error: () => {
-      throw new GraphQLError('Expected error')
-    }
-  }
+    Query: {
+        error: () => {
+            throw new GraphQLError('Expected error')
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
@@ -34,15 +34,17 @@ import { g, InferResolvers, buildSchema } from 'garph'
 import { GraphQLError } from 'graphql'
 
 const queryType = g.type('Query', {
-  error: g.string(),
+    error: g.string(),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    error: () => {
-      throw new GraphQLError('Expected error with extensions', { extensions: { code: 'EXPECTED_ERROR' } })
-    }
-  }
+    Query: {
+        error: () => {
+            throw new GraphQLError('Expected error with extensions', {
+                extensions: { code: 'EXPECTED_ERROR' },
+            })
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })

--- a/www/docs/advanced/file-uploads.md
+++ b/www/docs/advanced/file-uploads.md
@@ -14,19 +14,18 @@ import { g, InferResolvers, buildSchema } from 'garph'
 const file = g.scalarType<File, never>('File')
 
 const mutationType = g.type('Mutation', {
-  readTextFile: g.string()
-    .args({
-      file: g.ref(file),
-    })
+    readTextFile: g.string().args({
+        file: g.ref(file),
+    }),
 })
 
 const resolvers: InferResolvers<{ Mutation: typeof mutationType }, {}> = {
-  Mutation: {
-    readTextFile: async (parent, { file }, context, info) => {
-      const textContent = await file.text()
-      return textContent
-    }
-  }
+    Mutation: {
+        readTextFile: async (parent, { file }, context, info) => {
+            const textContent = await file.text()
+            return textContent
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })

--- a/www/docs/advanced/pagination.md
+++ b/www/docs/advanced/pagination.md
@@ -8,36 +8,39 @@ Garph creates a Relay-style paginated list when using `paginatedList` modifier a
 import { g, InferResolvers, buildSchema } from 'garph'
 
 const user = g.type('User', {
-  id: g.string().description('User ID'),
-  name: g.string().description('User name'),
+    id: g.string().description('User ID'),
+    name: g.string().description('User name'),
 })
 
 const queryType = g.type('Query', {
-  users: g.ref(user).paginatedList().args({ ...g.pageInfoArgs })
+    users: g
+        .ref(user)
+        .paginatedList()
+        .args({ ...g.pageInfoArgs }),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    users: (parent, args, context, info) => {
-      return {
-        edges: [
-          {
-            node: {
-              id: '1',
-              name: 'John',
-            },
-            cursor: '1'
-          }
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '1',
-          endCursor: '1'
-        }
-      }
-    }
-  }
+    Query: {
+        users: (parent, args, context, info) => {
+            return {
+                edges: [
+                    {
+                        node: {
+                            id: '1',
+                            name: 'John',
+                        },
+                        cursor: '1',
+                    },
+                ],
+                pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: '1',
+                    endCursor: '1',
+                },
+            }
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })

--- a/www/docs/advanced/relay.md
+++ b/www/docs/advanced/relay.md
@@ -8,38 +8,38 @@ Garph ships with Relay primitives, which allow you to faster develop Relay-compa
 import { g, InferResolvers, buildSchema } from 'garph'
 
 const user = g.node('UserNode', {
-  name: g.string().description('User name'),
+    name: g.string().description('User name'),
 })
 
 const userEdge = g.edge('UserEdge', g.ref(user))
 const userConnection = g.connection('UserConnection', g.ref(userEdge))
 
 const queryType = g.type('Query', {
-  users: g.ref(userConnection).args({ ...g.pageInfoArgs })
+    users: g.ref(userConnection).args({ ...g.pageInfoArgs }),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    users: (parent, args, context, info) => {
-      return {
-        edges: [
-          {
-            node: {
-              id: '1',
-              name: 'John',
-            },
-            cursor: '1',
-          },
-        ],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: '1',
-          endCursor: '1',
-        }
-      }
-    }
-  }
+    Query: {
+        users: (parent, args, context, info) => {
+            return {
+                edges: [
+                    {
+                        node: {
+                            id: '1',
+                            name: 'John',
+                        },
+                        cursor: '1',
+                    },
+                ],
+                pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: '1',
+                    endCursor: '1',
+                },
+            }
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })

--- a/www/docs/advanced/subscriptions.md
+++ b/www/docs/advanced/subscriptions.md
@@ -8,7 +8,7 @@ You can execute the following query in GraphQL playground to subscribe to the up
 
 ```graphql
 subscription {
-  counter
+    counter
 }
 ```
 
@@ -16,25 +16,28 @@ subscription {
 import { g, InferResolvers, buildSchema, Infer } from 'garph'
 
 const queryType = g.type('Query', {
-  greet: g.string()
+    greet: g.string(),
 })
 
 const subscriptionType = g.type('Subscription', {
-  counter: g.int()
+    counter: g.int(),
 })
 
-const resolvers: InferResolvers<{ Subscription: typeof subscriptionType }, {}> = {
-  Subscription: {
-    counter: {
-      subscribe: async function* (parent, args, context, info) {
-        for (let i = 100; i >= 0; i--) {
-          await new Promise((resolve) => setTimeout(resolve, 1000))
-          yield { counter: i }
-        }
-      }
+const resolvers: InferResolvers<{ Subscription: typeof subscriptionType }, {}> =
+    {
+        Subscription: {
+            counter: {
+                subscribe: async function* (parent, args, context, info) {
+                    for (let i = 100; i >= 0; i--) {
+                        await new Promise((resolve) =>
+                            setTimeout(resolve, 1000)
+                        )
+                        yield { counter: i }
+                    }
+                },
+            },
+        },
     }
-  }
-}
 
 const schema = buildSchema({ g, resolvers })
 ```

--- a/www/docs/advanced/testing.md
+++ b/www/docs/advanced/testing.md
@@ -8,58 +8,62 @@ Given the following Garph schema:
 import { g, InferResolvers, buildSchema } from 'garph'
 
 const queryType = g.type('Query', {
-  greet: g.string()
-    .args({
-      name: g.string().optional().default('Max')
-    })
-    .description('Greets a person')
+    greet: g
+        .string()
+        .args({
+            name: g.string().optional().default('Max'),
+        })
+        .description('Greets a person'),
 })
 
-const resolvers: InferResolvers<{ Query: typeof queryType }, { context: YogaInitialContext }> = {
-  Query: {
-    greet: (parent, args, context, info) => `Hello, ${args.name}`
-  }
+const resolvers: InferResolvers<
+    { Query: typeof queryType },
+    { context: YogaInitialContext }
+> = {
+    Query: {
+        greet: (parent, args, context, info) => `Hello, ${args.name}`,
+    },
 }
 ```
 
 We can come up a Step CI workflow that looks like this:
 
 ```yml
-version: "1.1"
+version: '1.1'
 name: Status Check
 env:
-  BASE_URL: "http://localhost:4000/graphql"
+    BASE_URL: 'http://localhost:4000/graphql'
 tests:
-  default_greeting:
-    steps:
-      - name: 'Get default greeting'
-        http:
-          url: '${{env.BASE_URL}}'
-          graphql:
-            query: '{ greet }'
-          check:
-            status: 200
-            json:
-              data:
-                greet: 'Hello, Max'
+    default_greeting:
+        steps:
+            - name: 'Get default greeting'
+              http:
+                  url: '${{env.BASE_URL}}'
+                  graphql:
+                      query: '{ greet }'
+                  check:
+                      status: 200
+                      json:
+                          data:
+                              greet: 'Hello, Max'
 
-  specific_greeting:
-    steps:
-      - name: 'Greet a specific person'
-        http:
-          url: '${{env.BASE_URL}}'
-          graphql:
-            query: |
-              query ($name: String) {
-                greet(name: $name)
-              }
-            variables:
-              name: Alice
-          check:
-            status: 200
-            json:
-              data:
-                greet: 'Hello, Alice'
+    specific_greeting:
+        steps:
+            - name: 'Greet a specific person'
+              http:
+                  url: '${{env.BASE_URL}}'
+                  graphql:
+                      query: |
+                          query ($name: String) {
+                            greet(name: $name)
+                          }
+                      variables:
+                          name: Alice
+                  check:
+                      status: 200
+                      json:
+                          data:
+                              greet: 'Hello, Alice'
 ```
 
 The first test checks if the query "greet" is working and returns the default greeting. The second test checks if the API correctly greets a specific person (in this case, Alice) when provided with a name variable.

--- a/www/docs/advanced/validation.md
+++ b/www/docs/advanced/validation.md
@@ -9,24 +9,26 @@ import { g, InferResolvers, buildSchema } from 'garph'
 import { GraphQLError } from 'graphql'
 
 const username = g.scalarType<string, string>('Username', {
-  serialize: (username) => username,
-  parseValue: (username) => {
-    if (username.length < 3) {
-      throw new GraphQLError('Username must be at least 3 characters long')
-    }
+    serialize: (username) => username,
+    parseValue: (username) => {
+        if (username.length < 3) {
+            throw new GraphQLError(
+                'Username must be at least 3 characters long'
+            )
+        }
 
-    return username
-  }
+        return username
+    },
 })
 
 const queryType = g.type('Query', {
-  login: g.string().args({ username }),
+    login: g.string().args({ username }),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    login: (parent, args) => `Welcome back, ${args.username}!`
-  }
+    Query: {
+        login: (parent, args) => `Welcome back, ${args.username}!`,
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
@@ -46,24 +48,26 @@ import { GraphQLError } from 'graphql'
 const usernameValidator = z.string().min(3)
 
 const username = g.scalarType<string, string>('Username', {
-  serialize: (username) => username,
-  parseValue: (username) => {
-    if (!usernameValidator.safeParse(username).success) {
-      throw new GraphQLError('Username must be at least 3 characters long')
-    }
+    serialize: (username) => username,
+    parseValue: (username) => {
+        if (!usernameValidator.safeParse(username).success) {
+            throw new GraphQLError(
+                'Username must be at least 3 characters long'
+            )
+        }
 
-    return username
-  }
+        return username
+    },
 })
 
 const queryType = g.type('Query', {
-  login: g.string().args({ username }),
+    login: g.string().args({ username }),
 })
 
 const resolvers: InferResolvers<{ Query: typeof queryType }, {}> = {
-  Query: {
-    login: (parent, args) => `Welcome back, ${args.username}!`
-  }
+    Query: {
+        login: (parent, args) => `Welcome back, ${args.username}!`,
+    },
 }
 
 const schema = buildSchema({ g, resolvers })

--- a/www/docs/guide/inferring-types.md
+++ b/www/docs/guide/inferring-types.md
@@ -8,7 +8,7 @@ Garph types can be inferred into TypeScript using the [`Infer`](/api/index.md#in
 import { g, Infer } from 'garph'
 
 const nameType = g.type('Name', {
-  greet: g.string()
+    greet: g.string(),
 })
 
 type NameType = Infer<typeof nameType>
@@ -18,7 +18,7 @@ Inferred type:
 
 ```ts
 type NameType = {
-  greet: string
+    greet: string
 }
 ```
 
@@ -30,7 +30,7 @@ Arguments on Garph types can be inferred into TypeScript using the [`InferArgs`]
 import { g, InferArgs } from 'garph'
 
 const nameType = g.type('Name', {
-  greet: g.string().args({ name: g.string().optional() })
+    greet: g.string().args({ name: g.string().optional() }),
 })
 
 type NameType = InferArgs<typeof nameType>
@@ -40,9 +40,9 @@ Inferred type:
 
 ```ts
 type NameType = {
-  greet: {
-    name: string | null | undefined
-  }
+    greet: {
+        name: string | null | undefined
+    }
 }
 ```
 
@@ -54,17 +54,21 @@ Resolver types can be inferred into TypeScript using the [`InferResolvers`](/api
 import { g, InferResolvers } from 'garph'
 
 const queryType = g.type('Query', {
-  greet: g.string()
-    .args({
-      name: g.string().optional().default('Max'),
-    })
-    .description('Greets a person')
+    greet: g
+        .string()
+        .args({
+            name: g.string().optional().default('Max'),
+        })
+        .description('Greets a person'),
 })
 
-const resolvers: InferResolvers<{ Query: typeof queryType }, { context: any, info: any }> = {
-  Query: {
-    greet: (parent, args, context, info) => `Hello, ${args.name}`
-  }
+const resolvers: InferResolvers<
+    { Query: typeof queryType },
+    { context: any; info: any }
+> = {
+    Query: {
+        greet: (parent, args, context, info) => `Hello, ${args.name}`,
+    },
 }
 ```
 

--- a/www/docs/guide/loaders.md
+++ b/www/docs/guide/loaders.md
@@ -10,16 +10,16 @@ In Garph, you can add loaders to fields by making a field resolver return an obj
 
 Loader functions receive one argument:
 
-- `queries`
-  Array of query objects:
-    - `parent`
-      The object that contains the result returned by the parent resolver. This argument is not used for root-level resolvers.
-    - `args`
-      The arguments provided to the field in the GraphQL query or mutation.
-    - `context`
-      An object containing any data that is shared across all resolvers for a single request. This can include information such as the currently authenticated user or a database connection.
-    - `info`
-      An object that contains information about the execution state of the query, such as the name of the field being resolved and the selection set.
+-   `queries`
+    Array of query objects:
+    -   `parent`
+        The object that contains the result returned by the parent resolver. This argument is not used for root-level resolvers.
+    -   `args`
+        The arguments provided to the field in the GraphQL query or mutation.
+    -   `context`
+        An object containing any data that is shared across all resolvers for a single request. This can include information such as the currently authenticated user or a database connection.
+    -   `info`
+        An object that contains information about the execution state of the query, such as the name of the field being resolved and the selection set.
 
 ## Specifying resolver functions
 
@@ -27,46 +27,52 @@ Loader functions receive one argument:
 import { g, InferResolvers, buildSchema, Infer } from 'garph'
 
 const Dog = g.type('Dog', {
-  name: g.string(),
-  owner: g.string().omitResolver()
+    name: g.string(),
+    owner: g.string().omitResolver(),
 })
 
 const queryType = g.type('Query', {
-  dogs: g.ref(() => Dog).list()
+    dogs: g.ref(() => Dog).list(),
 })
 
 const owners = {
-  Apollo: 'Mish',
-  Buddy: 'Sebastian'
+    Apollo: 'Mish',
+    Buddy: 'Sebastian',
 }
 
-type resolverTypes = InferResolvers<{ Query: typeof queryType, Dog: typeof Dog }, {}>
+type resolverTypes = InferResolvers<
+    { Query: typeof queryType; Dog: typeof Dog },
+    {}
+>
 
 const resolvers: resolverTypes = {
-  Query: {
-    dogs: (parent, args, context, info) => {
-      return [
-        {
-          name: 'Apollo',
+    Query: {
+        dogs: (parent, args, context, info) => {
+            return [
+                {
+                    name: 'Apollo',
+                },
+                {
+                    name: 'Buddy',
+                },
+            ]
         },
-        {
-          name: 'Buddy',
-        }
-      ]
-    }
-  },
-  Dog: {
-    owner: {
-      load (queries) {
-        // Promise with timeout added to demonstrate caching
-        return queries.map(q => new Promise(resolve => {
-          setTimeout(() => {
-            resolve(owners[q.parent.name])
-          }, 1000)
-        }))
-      }
-    }
-  }
+    },
+    Dog: {
+        owner: {
+            load(queries) {
+                // Promise with timeout added to demonstrate caching
+                return queries.map(
+                    (q) =>
+                        new Promise((resolve) => {
+                            setTimeout(() => {
+                                resolve(owners[q.parent.name])
+                            }, 1000)
+                        })
+                )
+            },
+        },
+    },
 }
 
 const schema = buildSchema({ g, resolvers })

--- a/www/docs/guide/resolvers.md
+++ b/www/docs/guide/resolvers.md
@@ -6,14 +6,14 @@ GraphQL resolvers are functions for fetching the data for a particular field in 
 
 Resolver functions receive four arguments:
 
-- `parent`
-  The object that contains the result returned by the parent resolver. This argument is not used for root-level resolvers.
-- `args`
-  The arguments provided to the field in the GraphQL query or mutation.
-- `context`
-  An object containing any data that is shared across all resolvers for a single request. This can include information such as the currently authenticated user or a database connection.
-- `info`
-  An object that contains information about the execution state of the query, such as the name of the field being resolved and the selection set.
+-   `parent`
+    The object that contains the result returned by the parent resolver. This argument is not used for root-level resolvers.
+-   `args`
+    The arguments provided to the field in the GraphQL query or mutation.
+-   `context`
+    An object containing any data that is shared across all resolvers for a single request. This can include information such as the currently authenticated user or a database connection.
+-   `info`
+    An object that contains information about the execution state of the query, such as the name of the field being resolved and the selection set.
 
 ## Specifying resolver functions
 

--- a/www/docs/guide/schemas.md
+++ b/www/docs/guide/schemas.md
@@ -32,7 +32,7 @@ An object type is a type in GraphQL that represents an object with a set of name
 
 ```ts
 g.type('User', {
-  name: g.string()
+    name: g.string(),
 })
 ```
 
@@ -40,7 +40,7 @@ GraphQL Type:
 
 ```graphql
 type User {
-  name: String!
+    name: String!
 }
 ```
 
@@ -130,8 +130,8 @@ From TypeScript Enum:
 
 ```ts
 enum Fruits {
-  Apples,
-  Oranges
+    Apples,
+    Oranges,
 }
 
 g.enumType('Fruits', Fruits)
@@ -141,8 +141,8 @@ GraphQL Type:
 
 ```graphql
 enum Fruits {
-  Apples
-  Oranges
+    Apples
+    Oranges
 }
 ```
 
@@ -166,7 +166,7 @@ Reference:
 
 ```ts
 const name = g.type('Name', {
-  greet: g.ref(otherType)
+    greet: g.ref(otherType),
 })
 ```
 
@@ -174,7 +174,7 @@ Circular Reference:
 
 ```ts
 const name = g.type('Name', {
-  greet: g.ref(() => name)
+    greet: g.ref(() => name),
 })
 ```
 
@@ -184,7 +184,7 @@ An interface is a type in GraphQL that defines a set of fields that can be imple
 
 ```ts
 g.interface('Name', {
-  greet: g.string()
+    greet: g.string(),
 })
 ```
 
@@ -192,7 +192,7 @@ GraphQL Type:
 
 ```graphql
 interface Name {
-  greet: String!
+    greet: String!
 }
 ```
 
@@ -216,7 +216,7 @@ An input type is a type in GraphQL that represents the input data for a mutation
 
 ```ts
 g.inputType('Name', {
-  greet: g.string()
+    greet: g.string(),
 })
 ```
 
@@ -224,7 +224,7 @@ GraphQL Type:
 
 ```graphql
 input Name {
-  greet: String!
+    greet: String!
 }
 ```
 
@@ -234,8 +234,8 @@ Custom scalars can be useful for handling specific data types that are not nativ
 
 ```ts
 g.scalarType<Date, number>('Date', {
-  serialize: (value) => value.getTime(),
-  parseValue: (value) => new Date(value)
+    serialize: (value) => value.getTime(),
+    parseValue: (value) => new Date(value),
 })
 ```
 
@@ -259,7 +259,7 @@ See: https://github.com/stepci/garph/issues/40
 
 ```ts
 g.node('User', {
-  name: g.string()
+    name: g.string(),
 })
 ```
 
@@ -267,8 +267,8 @@ GraphQL Type:
 
 ```graphql
 type User {
-  id: ID!
-  name: String!
+    id: ID!
+    name: String!
 }
 ```
 
@@ -282,8 +282,8 @@ GraphQL Type:
 
 ```graphql
 type UserEdge {
-  cursor: String!
-  node: User
+    cursor: String!
+    node: User
 }
 ```
 
@@ -297,8 +297,8 @@ GraphQL Type:
 
 ```graphql
 type UserConnection {
-  edges: [UserEdge]
-  pageInfo: PageInfo!
+    edges: [UserEdge]
+    pageInfo: PageInfo!
 }
 ```
 
@@ -312,10 +312,10 @@ GraphQL Type:
 
 ```graphql
 type PageInfo {
-  hasNextPage: Boolean!
-  hasPreviousPage: Boolean!
-  startCursor: String
-  endCursor: String
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
 }
 ```
 
@@ -341,7 +341,7 @@ Used to pass additional parameters to a query or a mutation. They can be used to
 
 ```ts
 g.type('Query', {
-  greet: g.string().args({ name: g.string() })
+    greet: g.string().args({ name: g.string() }),
 })
 ```
 
@@ -349,7 +349,7 @@ GraphQL Type:
 
 ```graphql
 type Query {
-  greet(name: String!): String!
+    greet(name: String!): String!
 }
 ```
 
@@ -381,7 +381,7 @@ Define a set of properties that extends an input, interface or object type
 
 ```ts
 const name = {
-  name: g.string()
+    name: g.string(),
 }
 
 const test = g.type('Test', {}).extend(name)
@@ -397,7 +397,7 @@ GraphQL Type:
 
 ```graphql
 type Test {
-  name: String!
+    name: String!
 }
 ```
 
@@ -438,7 +438,7 @@ g.string().required()
 Default values can be used to provide a fallback value if a requested value is not available. They can be specified for arguments, query variables, and input objects
 
 ```ts
-g.string().default("Default string")
+g.string().default('Default string')
 ```
 
 ### Description
@@ -446,7 +446,7 @@ g.string().default("Default string")
 A string that can be used to describe a schema element such as a field or an argument
 
 ```ts
-g.string().description("Description")
+g.string().description('Description')
 ```
 
 ### Deprecated
@@ -454,7 +454,7 @@ g.string().description("Description")
 Mark a field as deprecated. It is used to indicate that a schema element is no longer supported or recommended and should not be used in new code. When a deprecated schema element is used, a warning is generated to alert developers
 
 ```ts
-g.string().deprecated("Deprecation reason")
+g.string().deprecated('Deprecation reason')
 ```
 
 ### Omit Resolver

--- a/www/docs/index.md
+++ b/www/docs/index.md
@@ -16,8 +16,8 @@ Garph is a tool for building GraphQL APIs without codegen. It provides a fullsta
 
 Before you begin, make sure you have the following installed:
 
-- [Node.js](https://nodejs.org/) (LTS and above)
-- npm (included with Node)
+-   [Node.js](https://nodejs.org/) (LTS and above)
+-   npm (included with Node)
 
 ## Tutorial
 
@@ -26,6 +26,7 @@ Before you begin, make sure you have the following installed:
 To install Garph, run the following command in your terminal:
 
 ::: code-group
+
 ```sh [npm]
 $ npm i garph graphql-yoga
 ```
@@ -41,6 +42,7 @@ $ yarn add garph graphql-yoga
 ```sh [bun]
 $ bun i garph graphql-yoga
 ```
+
 :::
 
 This will install Garph and [Yoga](https://the-guild.dev/graphql/yoga-server) in your project.
@@ -54,19 +56,22 @@ The "Query" type is the entry point for queries in a GraphQL schema. It defines 
 Create a new file called `index.ts` and paste the following contents:
 
 ::: code-group
+
 ```ts [index.ts]
 import { g, InferResolvers, buildSchema } from 'garph'
 import { createYoga, YogaInitialContext } from 'graphql-yoga'
 import { createServer } from 'http'
 
 const queryType = g.type('Query', {
-  greet: g.string()
-    .args({
-      name: g.string().optional().default('Max')
-    })
-    .description('Greets a person')
+    greet: g
+        .string()
+        .args({
+            name: g.string().optional().default('Max'),
+        })
+        .description('Greets a person'),
 })
 ```
+
 :::
 
 This will import the required packages and create a new GraphQL schema a Query type, that has a field "greet", that takes an optional "name" argument of type string with the default value "Max".
@@ -75,10 +80,10 @@ The example above produces the following GraphQL schema:
 
 ```graphql
 type Query {
-  """
-  Greets a person
-  """
-  greet(name: String = "Max"): String!
+    """
+    Greets a person
+    """
+    greet(name: String = "Max"): String!
 }
 ```
 
@@ -89,6 +94,7 @@ type Query {
 GraphQL resolvers are functions for fetching the data for a particular field in a GraphQL query or mutation. When a client makes a GraphQL request, the GraphQL server invokes the corresponding resolver functions to retrieve the data for the requested fields.
 
 ::: code-group
+
 ```ts{13-17} [index.ts]
 import { g, InferResolvers, buildSchema } from 'garph'
 import { createYoga, YogaInitialContext } from 'graphql-yoga'
@@ -108,6 +114,7 @@ const resolvers: InferResolvers<{ Query: typeof queryType }, { context: YogaInit
   }
 }
 ```
+
 :::
 
 The above code defines a resolver function for a "greet" field on the "Query" type in a GraphQL schema. When a client sends a query requesting the "greet" field, this resolver function will be invoked by the GraphQL server to fetch and return the data for the field.
@@ -123,6 +130,7 @@ Although Garph holds no opinions of which server is being used to serve the Grap
 GraphQL Yoga can help simplify the process of building a GraphQL server, reduce boilerplate code, and provide useful features and tools to help you develop and debug your server more efficiently
 
 ::: code-group
+
 ```ts{19-24} [index.ts]
 import { g, InferResolvers, buildSchema } from 'garph'
 import { createYoga, YogaInitialContext } from 'graphql-yoga'
@@ -149,6 +157,7 @@ server.listen(4000, () => {
   console.info('Server is running on http://localhost:4000/graphql')
 })
 ```
+
 :::
 
 In the above code, we create a new GraphQL schema from our Garph schema and resolvers. After that, we create a new Yoga instance with the schema provided and serve Yoga using a http server included in Node.js on port 4000
@@ -175,7 +184,7 @@ To test the "greet" query, enter the following in the left pane:
 
 ```graphql
 query {
-  greet(name: "Max")
+    greet(name: "Max")
 }
 ```
 
@@ -183,9 +192,9 @@ Then, click the "Play" button to run the query. You should see the following res
 
 ```json
 {
-  "data": {
-    "greet": "Hello, Max"
-  }
+    "data": {
+        "greet": "Hello, Max"
+    }
 }
 ```
 

--- a/www/docs/integration/client/gqty.md
+++ b/www/docs/integration/client/gqty.md
@@ -11,6 +11,7 @@ GQty is a fundamentally new approach to a GraphQL client. It makes using your AP
 ## Installation
 
 ::: code-group
+
 ```sh [npm]
 $ npm i @garph/gqty
 ```
@@ -26,6 +27,7 @@ $ yarn add @garph/gqty
 ```sh [bun]
 $ bun i @garph/gqty
 ```
+
 :::
 
 ## Initialization
@@ -33,24 +35,28 @@ $ bun i @garph/gqty
 Example Schema:
 
 ::: code-group
+
 ```ts [schema.ts]
 import { g, buildSchema } from 'garph'
 
 export const queryType = g.type('Query', {
-  greet: g.string()
-    .args({
-      name: g.string().optional().default('Max'),
-    })
-    .description('Greets a person')
+    greet: g
+        .string()
+        .args({
+            name: g.string().optional().default('Max'),
+        })
+        .description('Greets a person'),
 })
 
 const schema = buildSchema({ g })
 ```
+
 :::
 
 Initializing the client:
 
 ::: code-group
+
 ```ts [client.ts]
 import { InferClient, createClient } from '@garph/gqty'
 import { createScalarsEnumsHash, createGeneratedSchema } from '@garph/gqty/dist/utils'
@@ -67,6 +73,7 @@ export const { useQuery, ... } = createClient<ClientTypes>({
 // Needed for the babel plugin
 export { schema as compiledSchema }
 ```
+
 :::
 
 Adding subscriptions support
@@ -76,6 +83,7 @@ npm i graphql-sse
 ```
 
 ::: code-group
+
 ```ts [client.ts]
 import { createClient as createSubscriptionsClient } from 'graphql-sse'
 
@@ -88,6 +96,7 @@ export const { useSubscription, ... } = createClient<ClientTypes>({
   })
 })
 ```
+
 :::
 
 ## Babel Plugin
@@ -95,13 +104,20 @@ export const { useSubscription, ... } = createClient<ClientTypes>({
 In production, you might want to use the babel plugin in order to replace the runtime dependencies (such as `generatedSchema`, `scalarsEnumsHash`) in your client config with statically-generated artefacts.
 
 ::: code-group
+
 ```json [.babelrc]
 {
-  "plugins": [["@garph/gqty/dist/plugin", {
-    "clientConfig": "./utils/client.ts"
-  }]]
+    "plugins": [
+        [
+            "@garph/gqty/dist/plugin",
+            {
+                "clientConfig": "./utils/client.ts"
+            }
+        ]
+    ]
 }
 ```
+
 :::
 
 ## Usage
@@ -114,10 +130,9 @@ Example:
 import { resolved, query } from './client'
 
 resolved(() => {
-  return query.greet({ name: 'Mish' })
-})
-.then(data => {
-  console.log(data)
+    return query.greet({ name: 'Mish' })
+}).then((data) => {
+    console.log(data)
 })
 ```
 
@@ -131,8 +146,8 @@ Example:
 import { useQuery } from './client'
 
 export default function Example() {
-  const query = useQuery()
-  return <p>{ query.greet({ name: 'Mish' }) }</p>
+    const query = useQuery()
+    return <p>{query.greet({ name: 'Mish' })}</p>
 }
 ```
 

--- a/www/docs/integration/server/graphql-yoga.md
+++ b/www/docs/integration/server/graphql-yoga.md
@@ -11,6 +11,7 @@ GraphQL Yoga is a batteries-included cross-platform, spec-compliant GraphQL serv
 ## Installation
 
 ::: code-group
+
 ```sh [npm]
 $ npm i graphql-yoga
 ```
@@ -26,6 +27,7 @@ $ yarn add graphql-yoga
 ```sh [bun]
 $ bun i graphql-yoga
 ```
+
 :::
 
 ## Serving Garph schema
@@ -35,13 +37,16 @@ import { g, InferResolvers, buildSchema } from 'garph'
 import { createYoga, YogaInitialContext } from 'graphql-yoga'
 
 const queryType = g.type('Query', {
-  greet: g.string()
+    greet: g.string(),
 })
 
-const resolvers: InferResolvers<{ Query: typeof queryType }, { context: YogaInitialContext }> = {
-  Query: {
-    greet: () => `Hello, World!`
-  }
+const resolvers: InferResolvers<
+    { Query: typeof queryType },
+    { context: YogaInitialContext }
+> = {
+    Query: {
+        greet: () => `Hello, World!`,
+    },
 }
 
 const schema = buildSchema({ g, resolvers })
@@ -50,4 +55,4 @@ const yoga = createYoga({ schema })
 
 ## Types
 
-- Context: `YogaInitialContext`
+-   Context: `YogaInitialContext`


### PR DESCRIPTION
A lot of lines... I know.

I was starting to dig into the code because I'm using Garph for a personal project and all the little formatting inconsistencies were kinda bothering me.

I tried to match the prettier config file as best I could to your companies style. That means 4 space wide tabs, no semicolons, and single quotes. A lot of the additional lines are from prettier breaking up statements, which I prefer, but you could change the prettierrc to something like below.

```json
{
    "trailingComma": "es5",
    "tabWidth": 4,
    "semi": false,
    "singleQuote": true,
    "printWidth": 150
}
```
This tells prettier that lines should go to 150 characters wide where possible.

If you want to do the formatting yourself the configuration file is in the first commit, while the changes are in the second.

Some people also like to set up a tool like Husky or pre-commit to run this on git commits, which I could do if you're welcome to it. 

Thanks for making a pretty cool library :)
